### PR TITLE
Use 'get a structured header' term from Fetch

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -58,7 +58,6 @@ urlPrefix: https://tools.ietf.org/html/draft-ietf-httpbis-header-structure; spec
         text: sh-token; url: #section-3.9
     type: abstract-op
         text: serialize Structured Header; url: #section-4.1
-        text: Structured Header parsing algorithm; url: #section-4.2.7
 urlPrefix: https://html.spec.whatwg.org/
     type: dfn
         text: top-level browsing context group; url: multipage/browsers.html#tlbc-group
@@ -143,9 +142,10 @@ Cross-Origin-Embedder-Policy = sh-token
 
 The only currently valid `Cross-Origin-Embedder-Policy` value is "`require-corp`".
 
-In order to support forward-compatibility with as-yet-unknown request types, user agents MUST ignore
-this header if it contains an invalid value. Likewise, user agents MUST ignore this header if the
-value cannot be parsed as a <a grammar>`sh-token`</a>.
+Note: In order to support forward-compatibility with as-yet-unknown request types, user agents will ignore
+this header if it contains an invalid value. Likewise, user agents will ignore this header if the
+value cannot be parsed as a <a grammar>`sh-token`</a>. Parameters are not allowed; user agents will
+ignore this header if any parameters are present.
 
 
 Parsing {#parsing}
@@ -157,24 +157,22 @@ To <dfn abstract-op local-lt="parse header">obtain a response's embedder policy<
 
 1.  Let |policy| be "`unsafe-none`".
 
-2.  Let |header| be the result of [=header list/getting=] `Cross-Origin-Embedder-Policy` from
+2.  Let |value| be the result of [=header list/get a structured header=]
+    `Cross-Origin-Embedder-Policy` and "`item`" from
     |response|'s [=response/header list=].
 
-3.  If |header| is not `null`:
+3.  If |value| is not `null` and is not failure:
 
-    1.  Set |header| to the result of [=isomorphic decoding=] |header|.
+    1. Let |parsed policy| be |value|[0].
 
-    2.  Let |parsed policy| be the result of executing the [$Structured Header parsing algorithm$]
-        with <var ignore>input_string</var> set to |header|, and <var ignore>header_type</var> set
-        to "`item`".
+    2. Let |parameters| be |value|[1].
 
-        If parsing fails, set |parsed policy| to "`unsafe-none`".
+    3. If |parsed policy| is not a [=structured header/token=], then return |policy|.
 
-        ISSUE(httpwg/http-extensions#662): The ASCII requirements of Structured Headers are
-        somewhat unclear to me. Do we need to check whether |header| is an [=ASCII string=] before
-        passing it into the parsing algorithm?
+    4. If |parameters| is not empty, then return |policy|.
 
-    3.  If |parsed policy| is "`require-corp`", set |policy| to "`require-corp`".
+    5. If |parsed policy| is "`require-corp`", then set |policy| to
+        "`require-corp`".
 
 4.  Return |policy|.
 

--- a/index.bs
+++ b/index.bs
@@ -171,6 +171,10 @@ To <dfn abstract-op local-lt="parse header">obtain a response's embedder policy<
 
     4. If |parameters| is not empty, then return |policy|.
 
+        ISSUE: This step is expected to change when the Structured Headers for HTTP specification is
+        more stable. See [whatwg/html issue #5172](https://github.com/whatwg/html/issues/5172).
+        [[I-D.ietf-httpbis-header-structure]]
+
     5. If |parsed policy| is "`require-corp`", then set |policy| to
         "`require-corp`".
 

--- a/index.html
+++ b/index.html
@@ -1221,8 +1221,8 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 2a881f0ee698433d75c6a1555514334adb37d8c7" name="generator">
-  <meta content="7ee7f1eb787a913a7085c88152caac3f3f7d8156" name="document-revision">
+  <meta content="Bikeshed version 811139e88557b020c23cfc4db749a6220e4f7dcb" name="generator">
+  <meta content="d14cdf6b6936d0e11be01627bea0d916df1320d2" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1422,7 +1422,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Cross-Origin Embedder Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2020-01-16">16 January 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2020-01-20">20 January 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>Issue Tracking:
@@ -1563,6 +1563,8 @@ ignore this header if any parameters are present.</p>
         <p>If <var>parsed policy</var> is not a <a data-link-type="dfn" href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.9" id="ref-for-section-3.9②">token</a>, then return <var>policy</var>.</p>
        <li data-md>
         <p>If <var>parameters</var> is not empty, then return <var>policy</var>.</p>
+        <p class="issue" id="issue-d56d22a8"><a class="self-link" href="#issue-d56d22a8"></a> This step is expected to change when the Structured Headers for HTTP specification is
+more stable. See <a href="https://github.com/whatwg/html/issues/5172">whatwg/html issue #5172</a>. <a data-link-type="biblio" href="#biblio-i-dietf-httpbis-header-structure">[I-D.ietf-httpbis-header-structure]</a></p>
        <li data-md>
         <p>If <var>parsed policy</var> is "<code>require-corp</code>", then set <var>policy</var> to
 "<code>require-corp</code>".</p>
@@ -2393,6 +2395,8 @@ is significantly simpler than imposing new constraints in the future.</p>
   </dl>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
+   <div class="issue"> This step is expected to change when the Structured Headers for HTTP specification is
+more stable. See <a href="https://github.com/whatwg/html/issues/5172">whatwg/html issue #5172</a>. <a data-link-type="biblio" href="#biblio-i-dietf-httpbis-header-structure">[I-D.ietf-httpbis-header-structure]</a><a href="#issue-d56d22a8"> ↵ </a></div>
    <div class="issue"> Anne suggested that we ought to fail closed instead in the presence of COEP in <a href="https://github.com/whatwg/fetch/pull/893#discussion_r274867414">a comment on the relevant PR</a>.
 That seems reasonable to me, if we can get some changes into CORP along the lines of <a href="https://github.com/whatwg/fetch/issues/760">whatwg/fetch#760</a>, as they seem like useful
 extensions, and I think it’ll be more difficult to ship them after inverting the

--- a/index.html
+++ b/index.html
@@ -1167,6 +1167,18 @@ Possible extra rowspan handling
 		margin-left: auto;
 		margin-right: auto;
 	}
+	.overlarge {
+		/* Magic to create good table positioning:
+		   "content column" is 50ems wide at max; less on smaller screens.
+		   Extra space (after ToC + content) is empty on the right.
+
+		   1. When table < content column, centers table in column.
+		   2. When content < table < available, left-aligns.
+		   3. When table > available, fills available + scroll bar.
+		*/ 
+		display: grid;
+		grid-template-columns: minmax(0, 50em);
+	}
 	.overlarge > table {
 		/* limit preferred width of table */
 		max-width: 50em;
@@ -1176,7 +1188,6 @@ Possible extra rowspan handling
 
 	@media (min-width: 55em) {
 		.overlarge {
-			margin-left: calc(13px + 26.5rem - 50vw);
 			margin-right: calc(13px + 26.5rem - 50vw);
 			max-width: none;
 		}
@@ -1184,14 +1195,12 @@ Possible extra rowspan handling
 	@media screen and (min-width: 78em) {
 		body:not(.toc-inline) .overlarge {
 			/* 30.5em body padding 50em content area */
-			margin-left: calc(40em - 50vw) !important;
 			margin-right: calc(40em - 50vw) !important;
 		}
 	}
 	@media screen and (min-width: 90em) {
 		body:not(.toc-inline) .overlarge {
 			/* 4em html margin 30.5em body padding 50em content area */
-			margin-left: 0 !important;
 			margin-right: calc(84.5em - 100vw) !important;
 		}
 	}
@@ -1212,8 +1221,8 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 83d3ceadc5400c8422976bbcbe49615aace9cf1e" name="generator">
-  <meta content="3eecea4eca0328c6c6959d8a978071121611bc60" name="document-revision">
+  <meta content="Bikeshed version 2a881f0ee698433d75c6a1555514334adb37d8c7" name="generator">
+  <meta content="7ee7f1eb787a913a7085c88152caac3f3f7d8156" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1413,7 +1422,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Cross-Origin Embedder Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2020-01-09">9 January 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2020-01-16">16 January 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>Issue Tracking:
@@ -1531,9 +1540,10 @@ value MUST be a <a data-link-type="dfn" href="https://tools.ietf.org/html/draft-
 <pre>Cross-Origin-Embedder-Policy = sh-token
 </pre>
    <p>The only currently valid <code>Cross-Origin-Embedder-Policy</code> value is "<code>require-corp</code>".</p>
-   <p>In order to support forward-compatibility with as-yet-unknown request types, user agents MUST ignore
-this header if it contains an invalid value. Likewise, user agents MUST ignore this header if the
-value cannot be parsed as a <a data-link-type="grammar" href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.9" id="ref-for-section-3.9①"><code>sh-token</code></a>.</p>
+   <p class="note" role="note"><span>Note:</span> In order to support forward-compatibility with as-yet-unknown request types, user agents will ignore
+this header if it contains an invalid value. Likewise, user agents will ignore this header if the
+value cannot be parsed as a <a data-link-type="grammar" href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.9" id="ref-for-section-3.9①"><code>sh-token</code></a>. Parameters are not allowed; user agents will
+ignore this header if any parameters are present.</p>
    <h3 class="heading settled" data-level="2.2" id="parsing"><span class="secno">2.2. </span><span class="content">Parsing</span><a class="self-link" href="#parsing"></a></h3>
    <div class="algorithm" data-algorithm="parsing the header">
      To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export data-local-lt="parse header" id="abstract-opdef-obtain-a-responses-embedder-policy">obtain a response’s embedder policy</dfn> given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response">response</a> (<var>response</var>): 
@@ -1541,28 +1551,28 @@ value cannot be parsed as a <a data-link-type="grammar" href="https://tools.ietf
      <li data-md>
       <p>Let <var>policy</var> be "<code>unsafe-none</code>".</p>
      <li data-md>
-      <p>Let <var>header</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-list-get" id="ref-for-concept-header-list-get">getting</a> <code>Cross-Origin-Embedder-Policy</code> from <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list">header list</a>.</p>
+      <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-list-get-structured-header" id="ref-for-concept-header-list-get-structured-header">get a structured header</a> <code>Cross-Origin-Embedder-Policy</code> and "<code>item</code>" from <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list">header list</a>.</p>
      <li data-md>
-      <p>If <var>header</var> is not <code>null</code>:</p>
+      <p>If <var>value</var> is not <code>null</code> and is not failure:</p>
       <ol>
        <li data-md>
-        <p>Set <var>header</var> to the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#isomorphic-decode" id="ref-for-isomorphic-decode">isomorphic decoding</a> <var>header</var>.</p>
+        <p>Let <var>parsed policy</var> be <var>value</var>[0].</p>
        <li data-md>
-        <p>Let <var>parsed policy</var> be the result of executing the <a data-link-type="abstract-op" href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.2.7" id="ref-for-section-4.2.7">Structured Header parsing algorithm</a> with <var>input_string</var> set to <var>header</var>, and <var>header_type</var> set
-to "<code>item</code>".</p>
-        <p>If parsing fails, set <var>parsed policy</var> to "<code>unsafe-none</code>".</p>
-        <p class="issue" id="issue-40cb8ace"><a class="self-link" href="#issue-40cb8ace"></a> The ASCII requirements of Structured Headers are
-somewhat unclear to me. Do we need to check whether <var>header</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string">ASCII string</a> before
-passing it into the parsing algorithm? <a href="https://github.com/httpwg/http-extensions/issues/662">&lt;https://github.com/httpwg/http-extensions/issues/662></a></p>
+        <p>Let <var>parameters</var> be <var>value</var>[1].</p>
        <li data-md>
-        <p>If <var>parsed policy</var> is "<code>require-corp</code>", set <var>policy</var> to "<code>require-corp</code>".</p>
+        <p>If <var>parsed policy</var> is not a <a data-link-type="dfn" href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.9" id="ref-for-section-3.9②">token</a>, then return <var>policy</var>.</p>
+       <li data-md>
+        <p>If <var>parameters</var> is not empty, then return <var>policy</var>.</p>
+       <li data-md>
+        <p>If <var>parsed policy</var> is "<code>require-corp</code>", then set <var>policy</var> to
+"<code>require-corp</code>".</p>
       </ol>
      <li data-md>
       <p>Return <var>policy</var>.</p>
     </ol>
     <div class="note" role="note">
       Note: This fails open (by defaulting to "<code>unsafe-none</code>") in the presence of a header that cannot be
-parsed as a <a data-link-type="dfn" href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.9" id="ref-for-section-3.9②">token</a>. This includes inadvertant lists created by combining
+parsed as a <a data-link-type="dfn" href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.9" id="ref-for-section-3.9③">token</a>. This includes inadvertant lists created by combining
 multiple instances of the <code>Cross-Origin-Embedder-Policy</code> header present in a given response: 
      <table class="data">
       <thead>
@@ -1756,7 +1766,7 @@ account, and to cover some <a data-link-type="dfn" href="https://fetch.spec.what
     <li data-md>
      <p class="assertion">ASSERT: <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-mode" id="ref-for-concept-request-mode②">mode</a> is "<code>no-cors</code>" or "<code>navigate</code>". If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-mode" id="ref-for-concept-request-mode③">mode</a> is "<code>navigate</code>", <var>embedder policy</var> is "<code>require-corp</code>".</p>
     <li data-md>
-     <p>Let <var>policy</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-list-get" id="ref-for-concept-header-list-get①">getting</a> <code>Cross-Origin-Resource-Policy</code> from <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list①">header list</a>.</p>
+     <p>Let <var>policy</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-list-get" id="ref-for-concept-header-list-get">getting</a> <code>Cross-Origin-Resource-Policy</code> from <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list①">header list</a>.</p>
     <li data-md>
      <p>If <var>policy</var> is <code>null</code>, and <var>embedder policy</var> is "<code>require-corp</code>", set <var>policy</var> to
 "<code>same-origin</code>".</p>
@@ -2049,8 +2059,13 @@ is significantly simpler than imposing new constraints in the future.</p>
   <aside class="dfn-panel" data-for="term-for-concept-header-list-get">
    <a href="https://fetch.spec.whatwg.org/#concept-header-list-get">https://fetch.spec.whatwg.org/#concept-header-list-get</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-header-list-get">2.2. Parsing</a>
-    <li><a href="#ref-for-concept-header-list-get①">3.2.1. Cross-Origin Resource Policy Checks</a>
+    <li><a href="#ref-for-concept-header-list-get">3.2.1. Cross-Origin Resource Policy Checks</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-header-list-get-structured-header">
+   <a href="https://fetch.spec.whatwg.org/#concept-header-list-get-structured-header">https://fetch.spec.whatwg.org/#concept-header-list-get-structured-header</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-header-list-get-structured-header">2.2. Parsing</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-response-header-list">
@@ -2229,12 +2244,6 @@ is significantly simpler than imposing new constraints in the future.</p>
     <li><a href="#ref-for-concept-origin-scheme">3.2.1. Cross-Origin Resource Policy Checks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.2.7">
-   <a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.2.7">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.2.7</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-section-4.2.7">2.2. Parsing</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-section-3.1">
    <a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.1">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.1</a><b>Referenced in:</b>
    <ul>
@@ -2245,7 +2254,7 @@ is significantly simpler than imposing new constraints in the future.</p>
    <a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.9">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.9</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.9">2.1. The Cross-Origin-Embedder-Policy HTTP Response Header</a> <a href="#ref-for-section-3.9①">(2)</a>
-    <li><a href="#ref-for-section-3.9②">2.2. Parsing</a>
+    <li><a href="#ref-for-section-3.9②">2.2. Parsing</a> <a href="#ref-for-section-3.9③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2258,19 +2267,7 @@ is significantly simpler than imposing new constraints in the future.</p>
    <a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.9">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.9</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.9">2.1. The Cross-Origin-Embedder-Policy HTTP Response Header</a> <a href="#ref-for-section-3.9①">(2)</a>
-    <li><a href="#ref-for-section-3.9②">2.2. Parsing</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-string">
-   <a href="https://infra.spec.whatwg.org/#ascii-string">https://infra.spec.whatwg.org/#ascii-string</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-ascii-string">2.2. Parsing</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-isomorphic-decode">
-   <a href="https://infra.spec.whatwg.org/#isomorphic-decode">https://infra.spec.whatwg.org/#isomorphic-decode</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-isomorphic-decode">2.2. Parsing</a>
+    <li><a href="#ref-for-section-3.9②">2.2. Parsing</a> <a href="#ref-for-section-3.9③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-serviceworkerglobalscope">
@@ -2311,6 +2308,7 @@ is significantly simpler than imposing new constraints in the future.</p>
      <li><span class="dfn-paneled" id="term-for-http-cross-origin-resource-policy" style="color:initial">cross-origin-resource-policy</span>
      <li><span class="dfn-paneled" id="term-for-concept-request-current-url" style="color:initial">current url</span>
      <li><span class="dfn-paneled" id="term-for-concept-header-list-get" style="color:initial">get</span>
+     <li><span class="dfn-paneled" id="term-for-concept-header-list-get-structured-header" style="color:initial">get a structured header</span>
      <li><span class="dfn-paneled" id="term-for-concept-response-header-list" style="color:initial">header list</span>
      <li><span class="dfn-paneled" id="term-for-concept-response-https-state" style="color:initial">https state</span>
      <li><span class="dfn-paneled" id="term-for-local-scheme" style="color:initial">local scheme</span>
@@ -2347,17 +2345,10 @@ is significantly simpler than imposing new constraints in the future.</p>
    <li>
     <a data-link-type="biblio">[I-D.ietf-httpbis-header-structure]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-section-4.2.7" style="color:initial">Structured Header parsing algorithm</span>
      <li><span class="dfn-paneled" id="term-for-section-3.1" style="color:initial">dictionary</span>
      <li><span class="dfn-paneled" id="term-for-section-3.9" style="color:initial">sh-token</span>
      <li><span class="dfn-paneled" id="term-for-" style="color:initial">structured header</span>
      <li><span class="dfn-paneled" id="term-for-section-3.9①" style="color:initial">token</span>
-    </ul>
-   <li>
-    <a data-link-type="biblio">[INFRA]</a> defines the following terms:
-    <ul>
-     <li><span class="dfn-paneled" id="term-for-ascii-string" style="color:initial">ascii string</span>
-     <li><span class="dfn-paneled" id="term-for-isomorphic-decode" style="color:initial">isomorphic decode</span>
     </ul>
    <li>
     <a data-link-type="biblio">[service-workers-1]</a> defines the following terms:
@@ -2384,8 +2375,6 @@ is significantly simpler than imposing new constraints in the future.</p>
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-i-dietf-httpbis-header-structure">[I-D.ietf-httpbis-header-structure]
    <dd>Mark Nottingham; Poul-Henning Kamp. <a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure">Structured Headers for HTTP</a>. ID. URL: <a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure</a>
-   <dt id="biblio-infra">[INFRA]
-   <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-service-workers-1">[SERVICE-WORKERS-1]
@@ -2404,9 +2393,6 @@ is significantly simpler than imposing new constraints in the future.</p>
   </dl>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
-   <div class="issue"> The ASCII requirements of Structured Headers are
-somewhat unclear to me. Do we need to check whether <var>header</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string">ASCII string</a> before
-passing it into the parsing algorithm? <a href="https://github.com/httpwg/http-extensions/issues/662">&lt;https://github.com/httpwg/http-extensions/issues/662></a><a href="#issue-40cb8ace"> ↵ </a></div>
    <div class="issue"> Anne suggested that we ought to fail closed instead in the presence of COEP in <a href="https://github.com/whatwg/fetch/pull/893#discussion_r274867414">a comment on the relevant PR</a>.
 That seems reasonable to me, if we can get some changes into CORP along the lines of <a href="https://github.com/whatwg/fetch/issues/760">whatwg/fetch#760</a>, as they seem like useful
 extensions, and I think it’ll be more difficult to ship them after inverting the


### PR DESCRIPTION
See whatwg/fetch#983

Change duplicate requirements in the Framework section to non-normative note.

Fail parsing if SH parameters are present, until SH is more stable.