### PR TITLE
Disambiguate header parsing

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -58,7 +58,7 @@ urlPrefix: https://tools.ietf.org/html/draft-ietf-httpbis-header-structure; spec
         text: sh-token; url: #section-3.9
     type: abstract-op
         text: serialize Structured Header; url: #section-4.1
-        text: Structured Header parsing algorithm; url: #section-4.2.7
+        text: Parsing a Token from Text; url: #section-4.2.6
 urlPrefix: https://html.spec.whatwg.org/
     type: dfn
         text: top-level browsing context group; url: multipage/browsers.html#tlbc-group
@@ -163,9 +163,8 @@ To <dfn abstract-op local-lt="parse header">obtain a response's embedder policy<
 
     1.  Set |header| to the result of [=isomorphic decoding=] |header|.
 
-    2.  Let |parsed policy| be the result of executing the [$Structured Header parsing algorithm$]
-        with <var ignore>input_string</var> set to |header|, and <var ignore>header_type</var> set
-        to "`item`".
+    2.  Let |parsed policy| be the result of [$Parsing a Token from Text$]
+        with <var ignore>input_string</var> set to |header|.
 
         If parsing fails, set |parsed policy| to "`none`".
 

--- a/index.html
+++ b/index.html
@@ -1213,7 +1213,7 @@ Possible extra rowspan handling
 	}
 </style>
   <meta content="Bikeshed version c2a4ab239714a7c0374d0c7ad8cb001030becba3" name="generator">
-  <meta content="8e81e277a63e192c8b7ff5f84ef929a9c11ee3e9" name="document-revision">
+  <meta content="915c808a750e17f553b1385e435ac2cad11761bb" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1548,8 +1548,7 @@ value cannot be parsed as a <a data-link-type="grammar" href="https://tools.ietf
        <li data-md>
         <p>Set <var>header</var> to the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#isomorphic-decode" id="ref-for-isomorphic-decode">isomorphic decoding</a> <var>header</var>.</p>
        <li data-md>
-        <p>Let <var>parsed policy</var> be the result of executing the <a data-link-type="abstract-op" href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.2.7" id="ref-for-section-4.2.7">Structured Header parsing algorithm</a> with <var>input_string</var> set to <var>header</var>, and <var>header_type</var> set
-to "<code>item</code>".</p>
+        <p>Let <var>parsed policy</var> be the result of <a data-link-type="abstract-op" href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.2.6" id="ref-for-section-4.2.6">Parsing a Token from Text</a> with <var>input_string</var> set to <var>header</var>.</p>
         <p>If parsing fails, set <var>parsed policy</var> to "<code>none</code>".</p>
         <p class="issue" id="issue-40cb8ace"><a class="self-link" href="#issue-40cb8ace"></a> The ASCII requirements of Structured Headers are
 somewhat unclear to me. Do we need to check whether <var>header</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string">ASCII string</a> before
@@ -2218,10 +2217,10 @@ is significantly simpler than imposing new constraints in the future.</p>
     <li><a href="#ref-for-concept-origin-scheme">3.2.1. Cross-Origin Resource Policy Checks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.2.7">
-   <a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.2.7">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.2.7</a><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="term-for-section-4.2.6">
+   <a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.2.6">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.2.6</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-section-4.2.7">2.2. Parsing</a>
+    <li><a href="#ref-for-section-4.2.6">2.2. Parsing</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-section-3.1">
@@ -2334,7 +2333,7 @@ is significantly simpler than imposing new constraints in the future.</p>
    <li>
     <a data-link-type="biblio">[I-D.ietf-httpbis-header-structure]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-section-4.2.7" style="color:initial">Structured Header parsing algorithm</span>
+     <li><span class="dfn-paneled" id="term-for-section-4.2.6" style="color:initial">Parsing a Token from Text</span>
      <li><span class="dfn-paneled" id="term-for-section-3.1" style="color:initial">dictionary</span>
      <li><span class="dfn-paneled" id="term-for-section-3.9" style="color:initial">sh-token</span>
      <li><span class="dfn-paneled" id="term-for-" style="color:initial">structured header</span>


### PR DESCRIPTION
The definition of the Cross-Origin-Embedder-Policy currently includes the
following text:

> In order to support forward-compatibility with as-yet-unknown request
> types, user agents MUST ignore [the Cross-Origin-Embedder-Policy HTTP
> Response Header] if it contains an invalid value. Likewise, user
> agents MUST ignore this header if the value cannot be parsed as a
> sh-token.

However, the subsequently-defined parsing algorithm recognize any "item"
value [1]. As a further complication, the Structured Header parsing
algorithm is misused: this proposal interprets the return value as a
string, but the return value is actually a tuple consisting of a string
and a map. That makes it unclear if/how parameters should influence the
result.

value                   | header definition  | parsing algorithm
------------------------|--------------------|------------------
`require-corp`          | `require-corp`     | `require-corp`
`"require-corp"`        | `none`             | `require-corp`
`*cmVxdWlyZS1jb3Jw*`    | `none`             | `require-corp`
`require-corp;`         | `none`             | ?
`require-corp; foo=bar` | `none`             | ?

Update the parsing algorithm to align with the description of the
header.

[1] https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-14#section-3.3

---

My guess is that the header definition is what's intended, so that's what I'm
proposing in this patch.

Should we remove the normative instructions for UAs from the definition (and
perhaps replace with instruction for authors)?

/cc @domenic @zcorpan