### PR TITLE
Report COEP violations in nested frame loading

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -402,6 +402,29 @@ If a document's [=document/embedder policy=] is "`require-corp`", then any docum
 [=nested browsing context=] must positively assert a "`require-corp`" [=/embedder policy=] (see
 [[#cascade-vs-require]]).
 
+To <dfn abstract-op lt="queue coep navigation violation">Queue a Cross-Origin Embedder Policy
+violation on navigation, given a [=request=] (|request|), a string (|endpoint|) and an
+[=environment settings object=] (|settings|), run the following steps:
+
+1.  Let |blocked url| be |request|'s [=request/URL=].
+
+    Note: This is not |request|'s [=request/current URL=] in order to avoid redirect
+    information leak.
+
+2.  Set |blocked url|'s [=url/username=] to the empty string, and its [=url/password=] to `null`.
+
+3.  Set |serialized blocked url| be the result of executing the
+    [URL serializer](https://url.spec.whatwg.org/#concept-url-serializer) on |blocked url|
+    with the |exclude fragment flag| set.
+
+4.  Let |body| be a new object containing the following properties with keys:
+
+    * key: "`type`", "`navigation`".
+    * key: "`blocked-url`", value: |serialized blocked url|.
+
+5.  [Queue](https://w3c.github.io/reporting/#queue-report) |body| as "`coep-navigation`" for
+    |endpoint| on |settings|.
+
 To <dfn abstract-op lt="process navigation response">check a navigation response's adherence to its
 embedder's policy</dfn> given a [=request=] (|request|), a [=response=] (|response|), and a target
 [=browsing context=] (|target|), execute the following steps, which will return "`Allowed`" or
@@ -415,54 +438,19 @@ embedder's policy</dfn> given a [=request=] (|request|), a [=response=] (|respon
 3.  Let |parent policy| be |target|'s [=container document=]'s [=document/embedder policy=].
 
 4.  If |parent policy|'s [=embedder policy/report only value=] is "`require-corp`" and
-       |parent policy|'s [=embedder policy/report only reporting endpoint=] is not null and
-       |response policy|'s [=embedder policy/value=] is "`unsafe-none`":
-
-    1.  Let |blocked url| be |request|'s [=request/URL=].
-
-        Note: This is not |request|'s [=request/current URL=] in order to avoid redirect
-        information leak.
-
-    2.  Set |blocked url|'s [=url/username=] to the empty string, and its [=url/password=] to `null`.
-
-    3.  Set |serialized blocked url| be the result of executing the
-        [URL serializer](https://url.spec.whatwg.org/#concept-url-serializer) on |blocked url|
-        with the |exclude fragment flag| set.
-
-    4.  Let |body| be a new object containing the following properties with keys:
-
-        * key: "`type`", "`navigation`".
-        * key: "`blocked-url`", value: |serialized blocked url|.
-
-    5.  [Queue](https://w3c.github.io/reporting/#queue-report) |body| as "`coep-navigation`" for
-        |parent policy|'s [=embedder policy/report only reporting endpoint=] on |target|'s
-        [=container document=].
+    |parent policy|'s [=embedder policy/report only reporting endpoint=] is not null and
+    |response policy|'s [=embedder policy/value=] is "`unsafe-none`", then
+    [$queue coep navigation violation|queue a Cross-Origin Embedder Policy vioalation on navigation]
+    with |request|, |parent policy|'s [=embedder policy/report only reporting endpoint=] and
+    |target|'s [=container document=].
 
 5.  If |parent policy|'s [=embedder policy/value=] is "`require-corp`" and |child policy|'s
        [=embedder policy/value=] is "`unsafe-none`":
 
-    1.  If |parent policy|'s [=embedder policy/reporting endpoint=] is not null:
-
-        1.  Let |blocked url| be |request|'s [=request/URL=].
-
-        Note: This is not |request|'s [=request/current URL=] in order to avoid redirect
-        information leak.
-
-        2.  Set |blocked url|'s [=url/username=] to the empty string, and its [=url/password=] to
-            `null`.
-
-        3.  Set |serialized blocked url| be the result of executing the
-            [URL serializer](https://url.spec.whatwg.org/#concept-url-serializer) on |blocked url|
-            with the |exclude fragment flag| set.
-
-        4.  Let |body| be a new object containing the following properties with keys:
-
-            * key: "`type`", "`navigation`".
-            * key: "`blocked-url`", value: |serialized blocked url|.
-
-        5.  [Queue](https://w3c.github.io/reporting/#queue-report) |body| as "`coep-navigation`" for
-            |parent policy|'s [=embedder policy/reporting endpoint=] on |target|'s
-            [=container document=].
+    1.  If |parent policy|'s [=embedder policy/reporting endpoint=] is not null, then [$queue coep
+        navigation violation|queue a Cross-Origin Embedder Policy vioalation on navigation] with
+        |request|, |parent policy|'s [=embedder policy/reporting endpoint=] and |target|'s
+        [=container document=].
 
     2.  Return "`Blocked`".
 

--- a/index.bs
+++ b/index.bs
@@ -403,20 +403,64 @@ If a document's [=document/embedder policy=] is "`require-corp`", then any docum
 [[#cascade-vs-require]]).
 
 To <dfn abstract-op lt="process navigation response">check a navigation response's adherence to its
-embedder's policy</dfn> given a [=response=] (|response|), and a target [=browsing context=]
-(|target|), execute the following steps, which will return "`Allowed`" or "`Blocked`" as
-appropriate:
+embedder's policy</dfn> given a [=request=] (|request|), a [=response=] (|response|), and a target
+[=browsing context=] (|target|), execute the following steps, which will return "`Allowed`" or
+"`Blocked`" as appropriate:
 
-1.  Let |response policy| be the result of [$parse header|obtaining an embedder policy$] from
+1.  Return "`Allowed`" if |target| is not a [=child browsing context=].
+
+2.  Let |response policy| be the result of [$parse header|obtaining an embedder policy$] from
     |response|.
 
-2.  Return "`Allowed`" if any of the following statements are true:
+3.  Let |parent policy| be |target|'s [=container document=]'s [=document/embedder policy=].
 
-    *   |target| is not a [=child browsing context=].
-    *   |target|'s [=container document=]'s [=document/embedder policy=] is "`unsafe-none`".
-    *   |response policy|'s [=embedder policy/value=] is "`require-corp`".
+4.  If |parent policy|'s [=embedder policy/report only value=] is "`require-corp`" and
+       |parent policy|'s [=embedder policy/report only reporting endpoint=] is not null and
+       |response policy|'s [=embedder policy/value=] is "`unsafe-none`":
 
-3.  Return "`Blocked`".
+    1.  Let |blocked url| be |request|'s [=request/URL=].
+
+    2.  Set |blocked url|'s [=url/username=] to the empty string, and its [=url/password=] to `null`.
+
+    3.  Set |serialized blocked url| be the result of executing the
+        [URL serializer](https://url.spec.whatwg.org/#concept-url-serializer) on |blocked url|
+        with the |exclude fragment flag| set.
+
+    4.  Let |body| be a new object containing the following properties with keys:
+
+        * key: "`type`", "`navigation`".
+        * key: "`blocked-url`", value: |serialized blocked url|.
+
+    5.  [Queue](https://w3c.github.io/reporting/#queue-report) |body| as "`coep-navigation`" for
+        |parent policy|'s [=embedder policy/report only reporting endpoint=] on |target|'s
+        [=container document=].
+
+5.  If |parent policy|'s [=embedder policy/value=] is "`require-corp`" and |child policy|'s
+       [=embedder policy/value=] is "`unsafe-none`":
+
+    1.  If |parent policy|'s [=embedder policy/reporting endpoint=] is not null:
+
+        1.  Let |blocked url| be |request|'s [=request/URL=].
+
+        2.  Set |blocked url|'s [=url/username=] to the empty string, and its [=url/password=] to
+            `null`.
+
+        3.  Set |serialized blocked url| be the result of executing the
+            [URL serializer](https://url.spec.whatwg.org/#concept-url-serializer) on |blocked url|
+            with the |exclude fragment flag| set.
+
+        4.  Let |body| be a new object containing the following properties with keys:
+
+            * key: "`type`", "`navigation`".
+            * key: "`blocked-url`", value: |serialized blocked url|.
+
+        5.  [Queue](https://w3c.github.io/reporting/#queue-report) |body| as "`coep-navigation`" for
+            |parent policy|'s [=embedder policy/reporting endpoint=] on |target|'s
+            [=container document=].
+
+    2.  Return "`Blocked`".
+
+6.  Return "`Allowed`".
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -420,6 +420,9 @@ embedder's policy</dfn> given a [=request=] (|request|), a [=response=] (|respon
 
     1.  Let |blocked url| be |request|'s [=request/URL=].
 
+        Note: This is not |request|'s [=request/current URL=] in order to avoid leaking redirect
+        information.
+
     2.  Set |blocked url|'s [=url/username=] to the empty string, and its [=url/password=] to `null`.
 
     3.  Set |serialized blocked url| be the result of executing the
@@ -441,6 +444,9 @@ embedder's policy</dfn> given a [=request=] (|request|), a [=response=] (|respon
     1.  If |parent policy|'s [=embedder policy/reporting endpoint=] is not null:
 
         1.  Let |blocked url| be |request|'s [=request/URL=].
+
+        Note: This is not |request|'s [=request/current URL=] in order to avoid leaking redirect
+        information.
 
         2.  Set |blocked url|'s [=url/username=] to the empty string, and its [=url/password=] to
             `null`.

--- a/index.bs
+++ b/index.bs
@@ -420,8 +420,8 @@ embedder's policy</dfn> given a [=request=] (|request|), a [=response=] (|respon
 
     1.  Let |blocked url| be |request|'s [=request/URL=].
 
-        Note: This is not |request|'s [=request/current URL=] in order to avoid leaking redirect
-        information.
+        Note: This is not |request|'s [=request/current URL=] in order to avoid redirect
+        information leak.
 
     2.  Set |blocked url|'s [=url/username=] to the empty string, and its [=url/password=] to `null`.
 
@@ -445,8 +445,8 @@ embedder's policy</dfn> given a [=request=] (|request|), a [=response=] (|respon
 
         1.  Let |blocked url| be |request|'s [=request/URL=].
 
-        Note: This is not |request|'s [=request/current URL=] in order to avoid leaking redirect
-        information.
+        Note: This is not |request|'s [=request/current URL=] in order to avoid redirect
+        information leak.
 
         2.  Set |blocked url|'s [=url/username=] to the empty string, and its [=url/password=] to
             `null`.

--- a/index.bs
+++ b/index.bs
@@ -403,7 +403,7 @@ If a document's [=document/embedder policy=] is "`require-corp`", then any docum
 [[#cascade-vs-require]]).
 
 To <dfn abstract-op lt="queue coep navigation violation">Queue a Cross-Origin Embedder Policy
-violation on navigation, given a [=request=] (|request|), a string (|endpoint|) and an
+violation on navigation</dfn> given a [=request=] (|request|), a string (|endpoint|) and an
 [=environment settings object=] (|settings|), run the following steps:
 
 1.  Let |blocked url| be |request|'s [=request/URL=].
@@ -439,16 +439,16 @@ embedder's policy</dfn> given a [=request=] (|request|), a [=response=] (|respon
 
 4.  If |parent policy|'s [=embedder policy/report only value=] is "`require-corp`" and
     |parent policy|'s [=embedder policy/report only reporting endpoint=] is not null and
-    |response policy|'s [=embedder policy/value=] is "`unsafe-none`", then
-    [$queue coep navigation violation|queue a Cross-Origin Embedder Policy vioalation on navigation]
-    with |request|, |parent policy|'s [=embedder policy/report only reporting endpoint=] and
-    |target|'s [=container document=].
+    |response policy|'s [=embedder policy/value=] is "`unsafe-none`", then [$queue coep navigation
+    violation|queue a Cross-Origin Embedder Policy vioalation on navigation$] with |request|,
+    |parent policy|'s [=embedder policy/report only reporting endpoint=] and |target|'s
+    [=container document=].
 
 5.  If |parent policy|'s [=embedder policy/value=] is "`require-corp`" and |child policy|'s
        [=embedder policy/value=] is "`unsafe-none`":
 
     1.  If |parent policy|'s [=embedder policy/reporting endpoint=] is not null, then [$queue coep
-        navigation violation|queue a Cross-Origin Embedder Policy vioalation on navigation] with
+        navigation violation|queue a Cross-Origin Embedder Policy vioalation on navigation$] with
         |request|, |parent policy|'s [=embedder policy/reporting endpoint=] and |target|'s
         [=container document=].
 

--- a/index.html
+++ b/index.html
@@ -1222,7 +1222,7 @@ Possible extra rowspan handling
 	}
 </style>
   <meta content="Bikeshed version 5721fde7f6b8111f662b83b678f9e181a9838206" name="generator">
-  <meta content="d4562974b99c4455514b839fefaad18c30aab981" name="document-revision">
+  <meta content="32b63ce1207d03c19aa592ca0821e0bf27865436" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1795,8 +1795,8 @@ embedder’s policy</dfn> given a <a data-link-type="dfn" href="https://fetch.sp
       <ol>
        <li data-md>
         <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">URL</a>.</p>
-        <p class="note" role="note"><span>Note:</span> This is not <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current URL</a> in order to avoid leaking redirect
-information.</p>
+        <p class="note" role="note"><span>Note:</span> This is not <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current URL</a> in order to avoid redirect
+information leak.</p>
        <li data-md>
         <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password">password</a> to <code>null</code>.</p>
        <li data-md>
@@ -1821,8 +1821,8 @@ information.</p>
          <li data-md>
           <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①">URL</a>.</p>
         </ol>
-        <p class="note" role="note"><span>Note:</span> This is not <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current URL</a> in order to avoid leaking redirect
-information.</p>
+        <p class="note" role="note"><span>Note:</span> This is not <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current URL</a> in order to avoid redirect
+information leak.</p>
         <ol start="2">
          <li data-md>
           <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username①">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password①">password</a> to <code>null</code>.</p>

--- a/index.html
+++ b/index.html
@@ -1222,7 +1222,7 @@ Possible extra rowspan handling
 	}
 </style>
   <meta content="Bikeshed version 5721fde7f6b8111f662b83b678f9e181a9838206" name="generator">
-  <meta content="c38c23638af1100c637dcadcf5e106a63eab6442" name="document-revision">
+  <meta content="d4562974b99c4455514b839fefaad18c30aab981" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1795,6 +1795,8 @@ embedder’s policy</dfn> given a <a data-link-type="dfn" href="https://fetch.sp
       <ol>
        <li data-md>
         <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">URL</a>.</p>
+        <p class="note" role="note"><span>Note:</span> This is not <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current URL</a> in order to avoid leaking redirect
+information.</p>
        <li data-md>
         <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password">password</a> to <code>null</code>.</p>
        <li data-md>
@@ -1818,6 +1820,10 @@ embedder’s policy</dfn> given a <a data-link-type="dfn" href="https://fetch.sp
         <ol>
          <li data-md>
           <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①">URL</a>.</p>
+        </ol>
+        <p class="note" role="note"><span>Note:</span> This is not <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current URL</a> in order to avoid leaking redirect
+information.</p>
+        <ol start="2">
          <li data-md>
           <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username①">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password①">password</a> to <code>null</code>.</p>
          <li data-md>
@@ -1882,14 +1888,14 @@ then set <var>policy</var> to "<code>same-origin</code>".</p>
        <p>Return <code>allowed</code>.</p>
       <dt data-md><code>same-origin</code>
       <dd data-md>
-       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin">origin</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin" id="ref-for-same-origin">same origin</a> with <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current URL</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin">origin</a>, then return <code>allowed</code>.</p>
+       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin">origin</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin" id="ref-for-same-origin">same origin</a> with <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url②">current URL</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin">origin</a>, then return <code>allowed</code>.</p>
        <p>Otherwise, return <code>blocked</code>.</p>
       <dt data-md><code>same-site</code>
       <dd data-md>
        <p>If both of the following statements are true, then return <code>allowed</code>:</p>
        <ul>
         <li data-md>
-         <p><var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-host" id="ref-for-concept-origin-host">host</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-site" id="ref-for-same-site">same site</a> with <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current URL</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-host" id="ref-for-concept-origin-host①">host</a>.</p>
+         <p><var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-host" id="ref-for-concept-origin-host">host</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-site" id="ref-for-same-site">same site</a> with <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url③">current URL</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-host" id="ref-for-concept-origin-host①">host</a>.</p>
         <li data-md>
          <p><var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin②">origin</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme">scheme</a> is "<code>https</code>", or <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-https-state" id="ref-for-concept-response-https-state">HTTPS state</a> is "<code>none</code>".</p>
        </ul>
@@ -2217,7 +2223,8 @@ is significantly simpler than imposing new constraints in the future.</p>
   <aside class="dfn-panel" data-for="term-for-concept-request-current-url">
    <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">https://fetch.spec.whatwg.org/#concept-request-current-url</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request-current-url">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-request-current-url①">(2)</a>
+    <li><a href="#ref-for-concept-request-current-url">3.1.2. Process a navigation response</a> <a href="#ref-for-concept-request-current-url①">(2)</a>
+    <li><a href="#ref-for-concept-request-current-url②">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-request-current-url③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-destination">

--- a/index.html
+++ b/index.html
@@ -1222,7 +1222,7 @@ Possible extra rowspan handling
 	}
 </style>
   <meta content="Bikeshed version 5721fde7f6b8111f662b83b678f9e181a9838206" name="generator">
-  <meta content="32b63ce1207d03c19aa592ca0821e0bf27865436" name="document-revision">
+  <meta content="92a5dad74b162677d89507d120cd496d0821b7de" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1422,7 +1422,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Cross-Origin Embedder Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2020-03-09">9 March 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2020-03-11">11 March 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>Issue Tracking:
@@ -1780,8 +1780,30 @@ item’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-en
    <h4 class="heading settled" data-level="3.1.2" id="process-navigation-response"><span class="secno">3.1.2. </span><span class="content">Process a navigation response</span><a class="self-link" href="#process-navigation-response"></a></h4>
    <div class="algorithm" data-algorithm="process a navigation response">
      If a document’s <a data-link-type="dfn" href="#document-embedder-policy" id="ref-for-document-embedder-policy⑥">embedder policy</a> is "<code>require-corp</code>", then any document it embeds in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context">nested browsing context</a> must positively assert a "<code>require-corp</code>" <a data-link-type="dfn" href="#embedder-policy" id="ref-for-embedder-policy⑦">embedder policy</a> (see <a href="#cascade-vs-require">§ 4.3 Cascading vs. requiring embedder policies</a>). 
+    <p>To <dfn data-dfn-type="abstract-op" data-export data-lt="queue coep navigation violation" id="abstract-opdef-queue-coep-navigation-violation">Queue a Cross-Origin Embedder Policy
+violation on navigation, given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> (<var>request</var>), a string (<var>endpoint</var>) and an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object①">environment settings object</a> (<var>settings</var>), run the following steps:<a class="self-link" href="#abstract-opdef-queue-coep-navigation-violation"></a></dfn></p>
+    <ol>
+     <li data-md>
+      <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">URL</a>.</p>
+      <p class="note" role="note"><span>Note:</span> This is not <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current URL</a> in order to avoid redirect
+information leak.</p>
+     <li data-md>
+      <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password">password</a> to <code>null</code>.</p>
+     <li data-md>
+      <p>Set <var>serialized blocked url</var> be the result of executing the <a href="https://url.spec.whatwg.org/#concept-url-serializer">URL serializer</a> on <var>blocked url</var> with the <var>exclude fragment flag</var> set.</p>
+     <li data-md>
+      <p>Let <var>body</var> be a new object containing the following properties with keys:</p>
+      <ul>
+       <li data-md>
+        <p>key: "<code>type</code>", "<code>navigation</code>".</p>
+       <li data-md>
+        <p>key: "<code>blocked-url</code>", value: <var>serialized blocked url</var>.</p>
+      </ul>
+     <li data-md>
+      <p><a href="https://w3c.github.io/reporting/#queue-report">Queue</a> <var>body</var> as "<code>coep-navigation</code>" for <var>endpoint</var> on <var>settings</var>.</p>
+    </ol>
     <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export data-lt="process navigation response" id="abstract-opdef-process-navigation-response">check a navigation response’s adherence to its
-embedder’s policy</dfn> given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a> (<var>response</var>), and a target <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing context</a> (<var>target</var>), execute the following steps, which will return "<code>Allowed</code>" or
+embedder’s policy</dfn> given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a> (<var>response</var>), and a target <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing context</a> (<var>target</var>), execute the following steps, which will return "<code>Allowed</code>" or
 "<code>Blocked</code>" as appropriate:</p>
     <ol>
      <li data-md>
@@ -1791,54 +1813,15 @@ embedder’s policy</dfn> given a <a data-link-type="dfn" href="https://fetch.sp
      <li data-md>
       <p>Let <var>parent policy</var> be <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document">container document</a>'s <a data-link-type="dfn" href="#document-embedder-policy" id="ref-for-document-embedder-policy⑦">embedder policy</a>.</p>
      <li data-md>
-      <p>If <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-value" id="ref-for-embedder-policy-report-only-value①">report only value</a> is "<code>require-corp</code>" and <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint④">report only reporting endpoint</a> is not null and <var>response policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value①">value</a> is "<code>unsafe-none</code>":</p>
-      <ol>
-       <li data-md>
-        <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">URL</a>.</p>
-        <p class="note" role="note"><span>Note:</span> This is not <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current URL</a> in order to avoid redirect
-information leak.</p>
-       <li data-md>
-        <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password">password</a> to <code>null</code>.</p>
-       <li data-md>
-        <p>Set <var>serialized blocked url</var> be the result of executing the <a href="https://url.spec.whatwg.org/#concept-url-serializer">URL serializer</a> on <var>blocked url</var> with the <var>exclude fragment flag</var> set.</p>
-       <li data-md>
-        <p>Let <var>body</var> be a new object containing the following properties with keys:</p>
-        <ul>
-         <li data-md>
-          <p>key: "<code>type</code>", "<code>navigation</code>".</p>
-         <li data-md>
-          <p>key: "<code>blocked-url</code>", value: <var>serialized blocked url</var>.</p>
-        </ul>
-       <li data-md>
-        <p><a href="https://w3c.github.io/reporting/#queue-report">Queue</a> <var>body</var> as "<code>coep-navigation</code>" for <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint⑤">report only reporting endpoint</a> on <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document①">container document</a>.</p>
-      </ol>
+      <p>If <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-value" id="ref-for-embedder-policy-report-only-value①">report only value</a> is "<code>require-corp</code>" and <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint④">report only reporting endpoint</a> is not null and <var>response policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value①">value</a> is "<code>unsafe-none</code>", then
+[$queue coep navigation violation|queue a Cross-Origin Embedder Policy vioalation on navigation]
+with <var>request</var>, <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint⑤">report only reporting endpoint</a> and <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document①">container document</a>.</p>
      <li data-md>
       <p>If <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value②">value</a> is "<code>require-corp</code>" and <var>child policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value③">value</a> is "<code>unsafe-none</code>":</p>
       <ol>
        <li data-md>
-        <p>If <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint④">reporting endpoint</a> is not null:</p>
-        <ol>
-         <li data-md>
-          <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①">URL</a>.</p>
-        </ol>
-        <p class="note" role="note"><span>Note:</span> This is not <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current URL</a> in order to avoid redirect
-information leak.</p>
-        <ol start="2">
-         <li data-md>
-          <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username①">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password①">password</a> to <code>null</code>.</p>
-         <li data-md>
-          <p>Set <var>serialized blocked url</var> be the result of executing the <a href="https://url.spec.whatwg.org/#concept-url-serializer">URL serializer</a> on <var>blocked url</var> with the <var>exclude fragment flag</var> set.</p>
-         <li data-md>
-          <p>Let <var>body</var> be a new object containing the following properties with keys:</p>
-          <ul>
-           <li data-md>
-            <p>key: "<code>type</code>", "<code>navigation</code>".</p>
-           <li data-md>
-            <p>key: "<code>blocked-url</code>", value: <var>serialized blocked url</var>.</p>
-          </ul>
-         <li data-md>
-          <p><a href="https://w3c.github.io/reporting/#queue-report">Queue</a> <var>body</var> as "<code>coep-navigation</code>" for <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint⑤">reporting endpoint</a> on <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document②">container document</a>.</p>
-        </ol>
+        <p>If <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint④">reporting endpoint</a> is not null, then [$queue coep
+navigation violation|queue a Cross-Origin Embedder Policy vioalation on navigation] with <var>request</var>, <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint⑤">reporting endpoint</a> and <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document②">container document</a>.</p>
        <li data-md>
         <p>Return "<code>Blocked</code>".</p>
       </ol>
@@ -1847,7 +1830,7 @@ information leak.</p>
     </ol>
    </div>
    <h3 class="heading settled" data-level="3.2" id="integration-fetch"><span class="secno">3.2. </span><span class="content">Integration with Fetch</span><a class="self-link" href="#integration-fetch"></a></h3>
-   <p>When fetching resources, user agents should examine both the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a>'s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client">client</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-reserved-client" id="ref-for-concept-request-reserved-client">reserved client</a> to determine the applicable <a data-link-type="dfn" href="#embedder-policy" id="ref-for-embedder-policy⑧">embedder policy</a>, and apply any constraints that policy expresses
+   <p>When fetching resources, user agents should examine both the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>'s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client">client</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-reserved-client" id="ref-for-concept-request-reserved-client">reserved client</a> to determine the applicable <a data-link-type="dfn" href="#embedder-policy" id="ref-for-embedder-policy⑧">embedder policy</a>, and apply any constraints that policy expresses
 to incoming responses. To do so, Fetch is patched as follows:</p>
    <ol>
     <li data-md>
@@ -1858,7 +1841,7 @@ account, and to cover some <a data-link-type="dfn" href="https://fetch.spec.what
    </ol>
    <h4 class="heading settled" data-level="3.2.1" id="corp-check"><span class="secno">3.2.1. </span><span class="content">Cross-Origin Resource Policy Checks</span><a class="self-link" href="#corp-check"></a></h4>
    <p>To perform a <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-cross-origin-resource-policy-internal-check">cross-origin resource policy internal check</dfn> given a string
-(<var>embedder policy value</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③">response</a> (<var>response</var>), run these
+(<var>embedder policy value</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③">response</a> (<var>response</var>), run these
 steps:</p>
    <ol>
     <li data-md>
@@ -1888,14 +1871,14 @@ then set <var>policy</var> to "<code>same-origin</code>".</p>
        <p>Return <code>allowed</code>.</p>
       <dt data-md><code>same-origin</code>
       <dd data-md>
-       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin">origin</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin" id="ref-for-same-origin">same origin</a> with <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url②">current URL</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin">origin</a>, then return <code>allowed</code>.</p>
+       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin">origin</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin" id="ref-for-same-origin">same origin</a> with <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current URL</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin">origin</a>, then return <code>allowed</code>.</p>
        <p>Otherwise, return <code>blocked</code>.</p>
       <dt data-md><code>same-site</code>
       <dd data-md>
        <p>If both of the following statements are true, then return <code>allowed</code>:</p>
        <ul>
         <li data-md>
-         <p><var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-host" id="ref-for-concept-origin-host">host</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-site" id="ref-for-same-site">same site</a> with <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url③">current URL</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-host" id="ref-for-concept-origin-host①">host</a>.</p>
+         <p><var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-host" id="ref-for-concept-origin-host">host</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-site" id="ref-for-same-site">same site</a> with <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url②">current URL</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-host" id="ref-for-concept-origin-host①">host</a>.</p>
         <li data-md>
          <p><var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin②">origin</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme">scheme</a> is "<code>https</code>", or <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-https-state" id="ref-for-concept-response-https-state">HTTPS state</a> is "<code>none</code>".</p>
        </ul>
@@ -1913,7 +1896,7 @@ extensions, and I think it’ll be more difficult to ship them after inverting t
 error-handling behavior.</p>
      </dl>
    </ol>
-   <p>To perform a <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-cross-origin-resource-policy-check">cross-origin resource policy check</dfn> given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④">response</a> (<var>response</var>), run these steps:</p>
+   <p>To perform a <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-cross-origin-resource-policy-check">cross-origin resource policy check</dfn> given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④">response</a> (<var>response</var>), run these steps:</p>
    <ol>
     <li data-md>
      <p>Let <var>embedder policy</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①">client</a>'s <a data-link-type="dfn" href="#environment-settings-object-embedder-policy" id="ref-for-environment-settings-object-embedder-policy">embedder policy</a>.</p>
@@ -1925,9 +1908,9 @@ result of running [$cross-origin resource policy internal check] with <a data-li
 steps:</p>
      <ol>
       <li data-md>
-       <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">URL</a>.</p>
+       <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①">URL</a>.</p>
       <li data-md>
-       <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username②">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password②">password</a> to <code>null</code>.</p>
+       <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username①">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password①">password</a> to <code>null</code>.</p>
       <li data-md>
        <p>Set <var>serialized blocked url</var> be the result of executing the <a href="https://url.spec.whatwg.org/#concept-url-serializer">URL serializer</a> on <var>blocked url</var> with
 the <var>exclude fragment flag</var> set.</p>
@@ -1948,9 +1931,9 @@ the <var>exclude fragment flag</var> set.</p>
      <p>If <var>embedder policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint⑥">reporting endpoint</a> is not <code>null</code> and <var>result</var> is <code>blocked</code>, then run these steps:</p>
      <ol>
       <li data-md>
-       <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url③">URL</a>.</p>
+       <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">URL</a>.</p>
       <li data-md>
-       <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username③">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password③">password</a> to <code>null</code>.</p>
+       <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username②">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password②">password</a> to <code>null</code>.</p>
       <li data-md>
        <p>Set <var>serialized blocked url</var> be the result of executing the <a href="https://url.spec.whatwg.org/#concept-url-serializer">URL serializer</a> on <var>blocked url</var> with
 the <var>exclude fragment flag</var> set.</p>
@@ -2184,6 +2167,7 @@ is significantly simpler than imposing new constraints in the future.</p>
    <li><a href="#abstract-opdef-obtain-a-responses-embedder-policy">obtain a response’s embedder policy</a><span>, in §2.3</span>
    <li><a href="#abstract-opdef-obtain-a-responses-embedder-policy">parse header</a><span>, in §2.3</span>
    <li><a href="#abstract-opdef-process-navigation-response">process navigation response</a><span>, in §3.1.2</span>
+   <li><a href="#abstract-opdef-queue-coep-navigation-violation">queue coep navigation violation</a><span>, in §3.1.2</span>
    <li><a href="#embedder-policy-reporting-endpoint">reporting endpoint</a><span>, in §3.1</span>
    <li><a href="#embedder-policy-report-only-reporting-endpoint">report only reporting endpoint</a><span>, in §3.1</span>
    <li><a href="#embedder-policy-report-only-value">report only value</a><span>, in §3.1</span>
@@ -2223,8 +2207,8 @@ is significantly simpler than imposing new constraints in the future.</p>
   <aside class="dfn-panel" data-for="term-for-concept-request-current-url">
    <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">https://fetch.spec.whatwg.org/#concept-request-current-url</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request-current-url">3.1.2. Process a navigation response</a> <a href="#ref-for-concept-request-current-url①">(2)</a>
-    <li><a href="#ref-for-concept-request-current-url②">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-request-current-url③">(2)</a>
+    <li><a href="#ref-for-concept-request-current-url">3.1.2. Process a navigation response</a>
+    <li><a href="#ref-for-concept-request-current-url①">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-request-current-url②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-destination">
@@ -2286,9 +2270,9 @@ is significantly simpler than imposing new constraints in the future.</p>
   <aside class="dfn-panel" data-for="term-for-concept-request">
    <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request">3.1.2. Process a navigation response</a>
-    <li><a href="#ref-for-concept-request①">3.2. Integration with Fetch</a>
-    <li><a href="#ref-for-concept-request②">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-request③">(2)</a>
+    <li><a href="#ref-for-concept-request">3.1.2. Process a navigation response</a> <a href="#ref-for-concept-request①">(2)</a>
+    <li><a href="#ref-for-concept-request②">3.2. Integration with Fetch</a>
+    <li><a href="#ref-for-concept-request③">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-request④">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-reserved-client">
@@ -2373,6 +2357,7 @@ is significantly simpler than imposing new constraints in the future.</p>
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">3.1. Integration with HTML</a>
+    <li><a href="#ref-for-environment-settings-object①">3.1.2. Process a navigation response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-global-object">
@@ -2485,8 +2470,8 @@ is significantly simpler than imposing new constraints in the future.</p>
   <aside class="dfn-panel" data-for="term-for-concept-url-password">
    <a href="https://url.spec.whatwg.org/#concept-url-password">https://url.spec.whatwg.org/#concept-url-password</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-password">3.1.2. Process a navigation response</a> <a href="#ref-for-concept-url-password①">(2)</a>
-    <li><a href="#ref-for-concept-url-password②">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-url-password③">(2)</a>
+    <li><a href="#ref-for-concept-url-password">3.1.2. Process a navigation response</a>
+    <li><a href="#ref-for-concept-url-password①">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-url-password②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
@@ -2498,8 +2483,8 @@ is significantly simpler than imposing new constraints in the future.</p>
   <aside class="dfn-panel" data-for="term-for-concept-url-username">
    <a href="https://url.spec.whatwg.org/#concept-url-username">https://url.spec.whatwg.org/#concept-url-username</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-username">3.1.2. Process a navigation response</a> <a href="#ref-for-concept-url-username①">(2)</a>
-    <li><a href="#ref-for-concept-url-username②">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-url-username③">(2)</a>
+    <li><a href="#ref-for-concept-url-username">3.1.2. Process a navigation response</a>
+    <li><a href="#ref-for-concept-url-username①">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-url-username②">(2)</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>

--- a/index.html
+++ b/index.html
@@ -1222,7 +1222,7 @@ Possible extra rowspan handling
 	}
 </style>
   <meta content="Bikeshed version 5721fde7f6b8111f662b83b678f9e181a9838206" name="generator">
-  <meta content="92a5dad74b162677d89507d120cd496d0821b7de" name="document-revision">
+  <meta content="9b6a66a83f434becedcb3eeac31eb98a7a09f89e" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1780,8 +1780,8 @@ item’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-en
    <h4 class="heading settled" data-level="3.1.2" id="process-navigation-response"><span class="secno">3.1.2. </span><span class="content">Process a navigation response</span><a class="self-link" href="#process-navigation-response"></a></h4>
    <div class="algorithm" data-algorithm="process a navigation response">
      If a document’s <a data-link-type="dfn" href="#document-embedder-policy" id="ref-for-document-embedder-policy⑥">embedder policy</a> is "<code>require-corp</code>", then any document it embeds in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context">nested browsing context</a> must positively assert a "<code>require-corp</code>" <a data-link-type="dfn" href="#embedder-policy" id="ref-for-embedder-policy⑦">embedder policy</a> (see <a href="#cascade-vs-require">§ 4.3 Cascading vs. requiring embedder policies</a>). 
-    <p>To <dfn data-dfn-type="abstract-op" data-export data-lt="queue coep navigation violation" id="abstract-opdef-queue-coep-navigation-violation">Queue a Cross-Origin Embedder Policy
-violation on navigation, given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> (<var>request</var>), a string (<var>endpoint</var>) and an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object①">environment settings object</a> (<var>settings</var>), run the following steps:<a class="self-link" href="#abstract-opdef-queue-coep-navigation-violation"></a></dfn></p>
+    <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export data-lt="queue coep navigation violation" id="abstract-opdef-queue-coep-navigation-violation">Queue a Cross-Origin Embedder Policy
+violation on navigation</dfn> given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> (<var>request</var>), a string (<var>endpoint</var>) and an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object①">environment settings object</a> (<var>settings</var>), run the following steps:</p>
     <ol>
      <li data-md>
       <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">URL</a>.</p>
@@ -1813,15 +1813,12 @@ embedder’s policy</dfn> given a <a data-link-type="dfn" href="https://fetch.sp
      <li data-md>
       <p>Let <var>parent policy</var> be <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document">container document</a>'s <a data-link-type="dfn" href="#document-embedder-policy" id="ref-for-document-embedder-policy⑦">embedder policy</a>.</p>
      <li data-md>
-      <p>If <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-value" id="ref-for-embedder-policy-report-only-value①">report only value</a> is "<code>require-corp</code>" and <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint④">report only reporting endpoint</a> is not null and <var>response policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value①">value</a> is "<code>unsafe-none</code>", then
-[$queue coep navigation violation|queue a Cross-Origin Embedder Policy vioalation on navigation]
-with <var>request</var>, <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint⑤">report only reporting endpoint</a> and <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document①">container document</a>.</p>
+      <p>If <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-value" id="ref-for-embedder-policy-report-only-value①">report only value</a> is "<code>require-corp</code>" and <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint④">report only reporting endpoint</a> is not null and <var>response policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value①">value</a> is "<code>unsafe-none</code>", then <a data-link-type="abstract-op" href="#abstract-opdef-queue-coep-navigation-violation" id="ref-for-abstract-opdef-queue-coep-navigation-violation">queue a Cross-Origin Embedder Policy vioalation on navigation</a> with <var>request</var>, <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint⑤">report only reporting endpoint</a> and <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document①">container document</a>.</p>
      <li data-md>
       <p>If <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value②">value</a> is "<code>require-corp</code>" and <var>child policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value③">value</a> is "<code>unsafe-none</code>":</p>
       <ol>
        <li data-md>
-        <p>If <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint④">reporting endpoint</a> is not null, then [$queue coep
-navigation violation|queue a Cross-Origin Embedder Policy vioalation on navigation] with <var>request</var>, <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint⑤">reporting endpoint</a> and <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document②">container document</a>.</p>
+        <p>If <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint④">reporting endpoint</a> is not null, then <a data-link-type="abstract-op" href="#abstract-opdef-queue-coep-navigation-violation" id="ref-for-abstract-opdef-queue-coep-navigation-violation①">queue a Cross-Origin Embedder Policy vioalation on navigation</a> with <var>request</var>, <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint⑤">reporting endpoint</a> and <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document②">container document</a>.</p>
        <li data-md>
         <p>Return "<code>Blocked</code>".</p>
       </ol>
@@ -2693,6 +2690,12 @@ error-handling behavior.<a href="#issue-4328816a"> ↵ </a></div>
    <b><a href="#abstract-opdef-initialize-a-global-objects-embedder-policy-from-a-response">#abstract-opdef-initialize-a-global-objects-embedder-policy-from-a-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-initialize-a-global-objects-embedder-policy-from-a-response">3.1. Integration with HTML</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="abstract-opdef-queue-coep-navigation-violation">
+   <b><a href="#abstract-opdef-queue-coep-navigation-violation">#abstract-opdef-queue-coep-navigation-violation</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-abstract-opdef-queue-coep-navigation-violation">3.1.2. Process a navigation response</a> <a href="#ref-for-abstract-opdef-queue-coep-navigation-violation①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-process-navigation-response">

--- a/index.html
+++ b/index.html
@@ -1222,7 +1222,7 @@ Possible extra rowspan handling
 	}
 </style>
   <meta content="Bikeshed version 5721fde7f6b8111f662b83b678f9e181a9838206" name="generator">
-  <meta content="8fe7a55c874811bb3a4fb0989c51d8905ddd4e08" name="document-revision">
+  <meta content="c38c23638af1100c637dcadcf5e106a63eab6442" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1422,7 +1422,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Cross-Origin Embedder Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2020-03-04">4 March 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2020-03-09">9 March 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>Issue Tracking:
@@ -1781,27 +1781,67 @@ item’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-en
    <div class="algorithm" data-algorithm="process a navigation response">
      If a document’s <a data-link-type="dfn" href="#document-embedder-policy" id="ref-for-document-embedder-policy⑥">embedder policy</a> is "<code>require-corp</code>", then any document it embeds in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context">nested browsing context</a> must positively assert a "<code>require-corp</code>" <a data-link-type="dfn" href="#embedder-policy" id="ref-for-embedder-policy⑦">embedder policy</a> (see <a href="#cascade-vs-require">§ 4.3 Cascading vs. requiring embedder policies</a>). 
     <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export data-lt="process navigation response" id="abstract-opdef-process-navigation-response">check a navigation response’s adherence to its
-embedder’s policy</dfn> given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a> (<var>response</var>), and a target <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing context</a> (<var>target</var>), execute the following steps, which will return "<code>Allowed</code>" or "<code>Blocked</code>" as
-appropriate:</p>
+embedder’s policy</dfn> given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a> (<var>response</var>), and a target <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing context</a> (<var>target</var>), execute the following steps, which will return "<code>Allowed</code>" or
+"<code>Blocked</code>" as appropriate:</p>
     <ol>
+     <li data-md>
+      <p>Return "<code>Allowed</code>" if <var>target</var> is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#child-browsing-context" id="ref-for-child-browsing-context①">child browsing context</a>.</p>
      <li data-md>
       <p>Let <var>response policy</var> be the result of <a data-link-type="abstract-op" href="#abstract-opdef-obtain-a-responses-embedder-policy" id="ref-for-abstract-opdef-obtain-a-responses-embedder-policy②">obtaining an embedder policy</a> from <var>response</var>.</p>
      <li data-md>
-      <p>Return "<code>Allowed</code>" if any of the following statements are true:</p>
-      <ul>
-       <li data-md>
-        <p><var>target</var> is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#child-browsing-context" id="ref-for-child-browsing-context①">child browsing context</a>.</p>
-       <li data-md>
-        <p><var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document">container document</a>'s <a data-link-type="dfn" href="#document-embedder-policy" id="ref-for-document-embedder-policy⑦">embedder policy</a> is "<code>unsafe-none</code>".</p>
-       <li data-md>
-        <p><var>response policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value①">value</a> is "<code>require-corp</code>".</p>
-      </ul>
+      <p>Let <var>parent policy</var> be <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document">container document</a>'s <a data-link-type="dfn" href="#document-embedder-policy" id="ref-for-document-embedder-policy⑦">embedder policy</a>.</p>
      <li data-md>
-      <p>Return "<code>Blocked</code>".</p>
+      <p>If <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-value" id="ref-for-embedder-policy-report-only-value①">report only value</a> is "<code>require-corp</code>" and <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint④">report only reporting endpoint</a> is not null and <var>response policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value①">value</a> is "<code>unsafe-none</code>":</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">URL</a>.</p>
+       <li data-md>
+        <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password">password</a> to <code>null</code>.</p>
+       <li data-md>
+        <p>Set <var>serialized blocked url</var> be the result of executing the <a href="https://url.spec.whatwg.org/#concept-url-serializer">URL serializer</a> on <var>blocked url</var> with the <var>exclude fragment flag</var> set.</p>
+       <li data-md>
+        <p>Let <var>body</var> be a new object containing the following properties with keys:</p>
+        <ul>
+         <li data-md>
+          <p>key: "<code>type</code>", "<code>navigation</code>".</p>
+         <li data-md>
+          <p>key: "<code>blocked-url</code>", value: <var>serialized blocked url</var>.</p>
+        </ul>
+       <li data-md>
+        <p><a href="https://w3c.github.io/reporting/#queue-report">Queue</a> <var>body</var> as "<code>coep-navigation</code>" for <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint⑤">report only reporting endpoint</a> on <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document①">container document</a>.</p>
+      </ol>
+     <li data-md>
+      <p>If <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value②">value</a> is "<code>require-corp</code>" and <var>child policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value③">value</a> is "<code>unsafe-none</code>":</p>
+      <ol>
+       <li data-md>
+        <p>If <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint④">reporting endpoint</a> is not null:</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①">URL</a>.</p>
+         <li data-md>
+          <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username①">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password①">password</a> to <code>null</code>.</p>
+         <li data-md>
+          <p>Set <var>serialized blocked url</var> be the result of executing the <a href="https://url.spec.whatwg.org/#concept-url-serializer">URL serializer</a> on <var>blocked url</var> with the <var>exclude fragment flag</var> set.</p>
+         <li data-md>
+          <p>Let <var>body</var> be a new object containing the following properties with keys:</p>
+          <ul>
+           <li data-md>
+            <p>key: "<code>type</code>", "<code>navigation</code>".</p>
+           <li data-md>
+            <p>key: "<code>blocked-url</code>", value: <var>serialized blocked url</var>.</p>
+          </ul>
+         <li data-md>
+          <p><a href="https://w3c.github.io/reporting/#queue-report">Queue</a> <var>body</var> as "<code>coep-navigation</code>" for <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint⑤">reporting endpoint</a> on <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document②">container document</a>.</p>
+        </ol>
+       <li data-md>
+        <p>Return "<code>Blocked</code>".</p>
+      </ol>
+     <li data-md>
+      <p>Return "<code>Allowed</code>".</p>
     </ol>
    </div>
    <h3 class="heading settled" data-level="3.2" id="integration-fetch"><span class="secno">3.2. </span><span class="content">Integration with Fetch</span><a class="self-link" href="#integration-fetch"></a></h3>
-   <p>When fetching resources, user agents should examine both the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a>'s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client">client</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-reserved-client" id="ref-for-concept-request-reserved-client">reserved client</a> to determine the applicable <a data-link-type="dfn" href="#embedder-policy" id="ref-for-embedder-policy⑧">embedder policy</a>, and apply any constraints that policy expresses
+   <p>When fetching resources, user agents should examine both the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a>'s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client">client</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-reserved-client" id="ref-for-concept-request-reserved-client">reserved client</a> to determine the applicable <a data-link-type="dfn" href="#embedder-policy" id="ref-for-embedder-policy⑧">embedder policy</a>, and apply any constraints that policy expresses
 to incoming responses. To do so, Fetch is patched as follows:</p>
    <ol>
     <li data-md>
@@ -1812,7 +1852,7 @@ account, and to cover some <a data-link-type="dfn" href="https://fetch.spec.what
    </ol>
    <h4 class="heading settled" data-level="3.2.1" id="corp-check"><span class="secno">3.2.1. </span><span class="content">Cross-Origin Resource Policy Checks</span><a class="self-link" href="#corp-check"></a></h4>
    <p>To perform a <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-cross-origin-resource-policy-internal-check">cross-origin resource policy internal check</dfn> given a string
-(<var>embedder policy value</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③">response</a> (<var>response</var>), run these
+(<var>embedder policy value</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③">response</a> (<var>response</var>), run these
 steps:</p>
    <ol>
     <li data-md>
@@ -1867,21 +1907,21 @@ extensions, and I think it’ll be more difficult to ship them after inverting t
 error-handling behavior.</p>
      </dl>
    </ol>
-   <p>To perform a <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-cross-origin-resource-policy-check">cross-origin resource policy check</dfn> given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④">response</a> (<var>response</var>), run these steps:</p>
+   <p>To perform a <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-cross-origin-resource-policy-check">cross-origin resource policy check</dfn> given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④">response</a> (<var>response</var>), run these steps:</p>
    <ol>
     <li data-md>
      <p>Let <var>embedder policy</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①">client</a>'s <a data-link-type="dfn" href="#environment-settings-object-embedder-policy" id="ref-for-environment-settings-object-embedder-policy">embedder policy</a>.</p>
     <li data-md>
      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-reserved-client" id="ref-for-concept-request-reserved-client①">reserved client</a> is not <code>null</code>, then set <var>embedder policy</var> to a new <a data-link-type="dfn" href="#embedder-policy" id="ref-for-embedder-policy①⓪">embedder policy</a>.</p>
     <li data-md>
-     <p>If <var>embedder policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint④">report only reporting endpoint</a> is not <code>null</code> and the
-result of running [$cross-origin resource policy internal check] with <a data-link-type="dfn" href="#embedder-policy-report-only-value" id="ref-for-embedder-policy-report-only-value①">report only value</a>, <var>request</var> and <var>response</var> is <code>blocked</code>, then run these
+     <p>If <var>embedder policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint⑥">report only reporting endpoint</a> is not <code>null</code> and the
+result of running [$cross-origin resource policy internal check] with <a data-link-type="dfn" href="#embedder-policy-report-only-value" id="ref-for-embedder-policy-report-only-value②">report only value</a>, <var>request</var> and <var>response</var> is <code>blocked</code>, then run these
 steps:</p>
      <ol>
       <li data-md>
-       <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">URL</a>.</p>
+       <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">URL</a>.</p>
       <li data-md>
-       <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password">password</a> to <code>null</code>.</p>
+       <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username②">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password②">password</a> to <code>null</code>.</p>
       <li data-md>
        <p>Set <var>serialized blocked url</var> be the result of executing the <a href="https://url.spec.whatwg.org/#concept-url-serializer">URL serializer</a> on <var>blocked url</var> with
 the <var>exclude fragment flag</var> set.</p>
@@ -1894,17 +1934,17 @@ the <var>exclude fragment flag</var> set.</p>
          <p>key: "<code>blocked-url</code>", value: <var>serialized blocked url</var>.</p>
        </ul>
       <li data-md>
-       <p><a href="https://w3c.github.io/reporting/#queue-report">Queue</a> <var>body</var> as "<code>coep</code>" for <var>embedder policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint⑤">report only reporting endpoint</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client②">client</a>.</p>
+       <p><a href="https://w3c.github.io/reporting/#queue-report">Queue</a> <var>body</var> as "<code>coep</code>" for <var>embedder policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint⑦">report only reporting endpoint</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client②">client</a>.</p>
      </ol>
     <li data-md>
-     <p>Let <var>result</var> be the result of running <a data-link-type="abstract-op" href="#abstract-opdef-cross-origin-resource-policy-internal-check" id="ref-for-abstract-opdef-cross-origin-resource-policy-internal-check">cross-origin resource policy internal check</a> with <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value②">value</a>, <var>request</var> and <var>response</var>.</p>
+     <p>Let <var>result</var> be the result of running <a data-link-type="abstract-op" href="#abstract-opdef-cross-origin-resource-policy-internal-check" id="ref-for-abstract-opdef-cross-origin-resource-policy-internal-check">cross-origin resource policy internal check</a> with <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value④">value</a>, <var>request</var> and <var>response</var>.</p>
     <li data-md>
-     <p>If <var>embedder policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint④">reporting endpoint</a> is not <code>null</code> and <var>result</var> is <code>blocked</code>, then run these steps:</p>
+     <p>If <var>embedder policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint⑥">reporting endpoint</a> is not <code>null</code> and <var>result</var> is <code>blocked</code>, then run these steps:</p>
      <ol>
       <li data-md>
-       <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①">URL</a>.</p>
+       <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url③">URL</a>.</p>
       <li data-md>
-       <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username①">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password①">password</a> to <code>null</code>.</p>
+       <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username③">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password③">password</a> to <code>null</code>.</p>
       <li data-md>
        <p>Set <var>serialized blocked url</var> be the result of executing the <a href="https://url.spec.whatwg.org/#concept-url-serializer">URL serializer</a> on <var>blocked url</var> with
 the <var>exclude fragment flag</var> set.</p>
@@ -1917,7 +1957,7 @@ the <var>exclude fragment flag</var> set.</p>
          <p>key: "<code>blocked-url</code>", value: <var>serialized blocked url</var>.</p>
        </ul>
       <li data-md>
-       <p><a href="https://w3c.github.io/reporting/#queue-report">Queue</a> <var>body</var> as "<code>coep</code>" for <var>embedder policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint⑤">reporting endpoint</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client③">client</a>.</p>
+       <p><a href="https://w3c.github.io/reporting/#queue-report">Queue</a> <var>body</var> as "<code>coep</code>" for <var>embedder policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint⑦">reporting endpoint</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client③">client</a>.</p>
      </ol>
     <li data-md>
      <p>Return <var>result</var>.</p>
@@ -2239,8 +2279,9 @@ is significantly simpler than imposing new constraints in the future.</p>
   <aside class="dfn-panel" data-for="term-for-concept-request">
    <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request">3.2. Integration with Fetch</a>
-    <li><a href="#ref-for-concept-request①">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-request②">(2)</a>
+    <li><a href="#ref-for-concept-request">3.1.2. Process a navigation response</a>
+    <li><a href="#ref-for-concept-request①">3.2. Integration with Fetch</a>
+    <li><a href="#ref-for-concept-request②">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-request③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-reserved-client">
@@ -2318,7 +2359,7 @@ is significantly simpler than imposing new constraints in the future.</p>
   <aside class="dfn-panel" data-for="term-for-bc-container-document">
    <a href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document">https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-bc-container-document">3.1.2. Process a navigation response</a>
+    <li><a href="#ref-for-bc-container-document">3.1.2. Process a navigation response</a> <a href="#ref-for-bc-container-document①">(2)</a> <a href="#ref-for-bc-container-document②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-environment-settings-object">
@@ -2437,7 +2478,8 @@ is significantly simpler than imposing new constraints in the future.</p>
   <aside class="dfn-panel" data-for="term-for-concept-url-password">
    <a href="https://url.spec.whatwg.org/#concept-url-password">https://url.spec.whatwg.org/#concept-url-password</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-password">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-url-password①">(2)</a>
+    <li><a href="#ref-for-concept-url-password">3.1.2. Process a navigation response</a> <a href="#ref-for-concept-url-password①">(2)</a>
+    <li><a href="#ref-for-concept-url-password②">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-url-password③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
@@ -2449,7 +2491,8 @@ is significantly simpler than imposing new constraints in the future.</p>
   <aside class="dfn-panel" data-for="term-for-concept-url-username">
    <a href="https://url.spec.whatwg.org/#concept-url-username">https://url.spec.whatwg.org/#concept-url-username</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-username">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-url-username①">(2)</a>
+    <li><a href="#ref-for-concept-url-username">3.1.2. Process a navigation response</a> <a href="#ref-for-concept-url-username①">(2)</a>
+    <li><a href="#ref-for-concept-url-username②">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-url-username③">(2)</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -2603,8 +2646,8 @@ error-handling behavior.<a href="#issue-4328816a"> ↵ </a></div>
    <b><a href="#embedder-policy-value">#embedder-policy-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-embedder-policy-value">2.3. Parsing</a>
-    <li><a href="#ref-for-embedder-policy-value①">3.1.2. Process a navigation response</a>
-    <li><a href="#ref-for-embedder-policy-value②">3.2.1. Cross-Origin Resource Policy Checks</a>
+    <li><a href="#ref-for-embedder-policy-value①">3.1.2. Process a navigation response</a> <a href="#ref-for-embedder-policy-value②">(2)</a> <a href="#ref-for-embedder-policy-value③">(3)</a>
+    <li><a href="#ref-for-embedder-policy-value④">3.2.1. Cross-Origin Resource Policy Checks</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="embedder-policy-reporting-endpoint">
@@ -2612,14 +2655,16 @@ error-handling behavior.<a href="#issue-4328816a"> ↵ </a></div>
    <ul>
     <li><a href="#ref-for-embedder-policy-reporting-endpoint">2.3. Parsing</a>
     <li><a href="#ref-for-embedder-policy-reporting-endpoint①">3.1.1. Initializing a global object’s Embedder policy</a> <a href="#ref-for-embedder-policy-reporting-endpoint②">(2)</a> <a href="#ref-for-embedder-policy-reporting-endpoint③">(3)</a>
-    <li><a href="#ref-for-embedder-policy-reporting-endpoint④">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-embedder-policy-reporting-endpoint⑤">(2)</a>
+    <li><a href="#ref-for-embedder-policy-reporting-endpoint④">3.1.2. Process a navigation response</a> <a href="#ref-for-embedder-policy-reporting-endpoint⑤">(2)</a>
+    <li><a href="#ref-for-embedder-policy-reporting-endpoint⑥">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-embedder-policy-reporting-endpoint⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="embedder-policy-report-only-value">
    <b><a href="#embedder-policy-report-only-value">#embedder-policy-report-only-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-embedder-policy-report-only-value">2.3. Parsing</a>
-    <li><a href="#ref-for-embedder-policy-report-only-value①">3.2.1. Cross-Origin Resource Policy Checks</a>
+    <li><a href="#ref-for-embedder-policy-report-only-value①">3.1.2. Process a navigation response</a>
+    <li><a href="#ref-for-embedder-policy-report-only-value②">3.2.1. Cross-Origin Resource Policy Checks</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="embedder-policy-report-only-reporting-endpoint">
@@ -2627,7 +2672,8 @@ error-handling behavior.<a href="#issue-4328816a"> ↵ </a></div>
    <ul>
     <li><a href="#ref-for-embedder-policy-report-only-reporting-endpoint">2.3. Parsing</a>
     <li><a href="#ref-for-embedder-policy-report-only-reporting-endpoint①">3.1.1. Initializing a global object’s Embedder policy</a> <a href="#ref-for-embedder-policy-report-only-reporting-endpoint②">(2)</a> <a href="#ref-for-embedder-policy-report-only-reporting-endpoint③">(3)</a>
-    <li><a href="#ref-for-embedder-policy-report-only-reporting-endpoint④">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-embedder-policy-report-only-reporting-endpoint⑤">(2)</a>
+    <li><a href="#ref-for-embedder-policy-report-only-reporting-endpoint④">3.1.2. Process a navigation response</a> <a href="#ref-for-embedder-policy-report-only-reporting-endpoint⑤">(2)</a>
+    <li><a href="#ref-for-embedder-policy-report-only-reporting-endpoint⑥">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-embedder-policy-report-only-reporting-endpoint⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="document-embedder-policy">


### PR DESCRIPTION
Modify the "check a navigation response’s adherence to its
embedder’s policy" logic so as to report (possibly potential)
COEP violations.