### PR TITLE
Fix coep violation report type for CORP

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -611,7 +611,7 @@ To perform a <dfn abstract-op>cross-origin resource policy check</dfn> given a [
 
     4.  Let |body| be a new object containing the following properties with keys:
 
-        * key: "`type`", value: "`CORP`".
+        * key: "`type`", value: "`corp`".
 
         * key: "`blocked-url`", value: |serialized blocked url|.
 
@@ -635,7 +635,7 @@ To perform a <dfn abstract-op>cross-origin resource policy check</dfn> given a [
 
     4.  Let |body| be a new object containing the following properties with keys:
 
-        * key: "`type`", value: "`CORP`".
+        * key: "`type`", value: "`corp`".
 
         * key: "`blocked-url`", value: |serialized blocked url|.
 

--- a/index.html
+++ b/index.html
@@ -1222,7 +1222,7 @@ Possible extra rowspan handling
 	}
 </style>
   <meta content="Bikeshed version 5721fde7f6b8111f662b83b678f9e181a9838206" name="generator">
-  <meta content="e59fbaa66de7380dd89f0275eaa3cee25ec65b5e" name="document-revision">
+  <meta content="ba35ebd34586e3fa7b8cba8187f5e14065120800" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1422,7 +1422,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Cross-Origin Embedder Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2020-04-20">20 April 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2020-05-07">7 May 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>Issue Tracking:
@@ -1958,7 +1958,7 @@ the <var>exclude fragment flag</var> set.</p>
         <p>Let <var>body</var> be a new object containing the following properties with keys:</p>
         <ul>
          <li data-md>
-          <p>key: "<code>type</code>", value: "<code>CORP</code>".</p>
+          <p>key: "<code>type</code>", value: "<code>corp</code>".</p>
          <li data-md>
           <p>key: "<code>blocked-url</code>", value: <var>serialized blocked url</var>.</p>
         </ul>
@@ -1981,7 +1981,7 @@ the <var>exclude fragment flag</var> set.</p>
         <p>Let <var>body</var> be a new object containing the following properties with keys:</p>
         <ul>
          <li data-md>
-          <p>key: "<code>type</code>", value: "<code>CORP</code>".</p>
+          <p>key: "<code>type</code>", value: "<code>corp</code>".</p>
          <li data-md>
           <p>key: "<code>blocked-url</code>", value: <var>serialized blocked url</var>.</p>
         </ul>


### PR DESCRIPTION
Change "CORP" to "corp", so as to be consistent with other values.

Pointed out at:
https://crrev.com/c/2076223/11/third_party/blink/web_tests/external/wpt/html/cross-origin-embedder-policy/reporting.https.html