### PR TITLE
Have DedicatedWorker use COEP in response headers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -413,7 +413,7 @@ violation on worker initialization</dfn> given a [=request=] (|request|), a stri
 
 4.  Let |body| be a new object containing the following properties with keys:
 
-    * key: "`type`", "`worker initializatoin`".
+    * key: "`type`", "`worker initialization`".
     * key: "`blocked-url`", value: |serialized blocked url|.
 
 5.  [Queue](https://w3c.github.io/reporting/#queue-report) |body| as "`coep`" for

--- a/index.bs
+++ b/index.bs
@@ -402,8 +402,8 @@ violation on worker initialization</dfn> given a [=request=] (|request|), a stri
 
 1.  Let |blocked url| be |request|'s [=request/URL=].
 
-    Note: This is not |request|'s [=request/current URL=] in order to avoid redirect
-    information leak.
+    Note: This is not |request|'s [=request/current URL=] in order to avoid leaking information
+    about redirect targets (see https://w3c.github.io/webappsec-csp/#security-violation-reports).
 
 2.  Set |blocked url|'s [=url/username=] to the empty string, and its [=url/password=] to `null`.
 

--- a/index.bs
+++ b/index.bs
@@ -152,7 +152,7 @@ In order to support forward-compatibility with as-yet-unknown request types, use
 this header if it contains an invalid value. Likewise, user agents MUST ignore this header if the
 value cannot be parsed as a <a grammar>`sh-token`</a>.
 
-The `Cross-Origin-Embedder-Policy-Report-Only` HTTP Response Header {#COEP}
+The `Cross-Origin-Embedder-Policy-Report-Only` HTTP Response Header {#COEP-RO}
 ----------------------------------------------------------------
 
 The <dfn http-header>`Cross-Origin-Embedder-Policy-Report-Only`</dfn> HTTP response header field

--- a/index.bs
+++ b/index.bs
@@ -324,9 +324,9 @@ so, HTML is patched as follows:
     > 6.  Call [$initialize a global object's embedder policy from a response$] given
     >     <var ignore>worker global scope</var> and <var ignore>response</var>.
     >
-    > 7.  If the result of [$cheking a global object's embedder policy$] given
-    >     <var ignore>worker global scope</var> and <var ignore>response</var> is "`blocked`", then
-    >     set |response| to a [=network error=].
+    > 7.  If the result of [$check a global object's embedder policy$] given
+    >     <var ignore>request</var>, <var ignore>worker global scope</var> and
+    >     <var ignore>owner</var> is "`blocked`", then set |response| to a [=network error=].
 
 6.  The [$process a navigate fetch$] algorithm runs the [$cross-origin resource policy check$] for
     navigation for nested browsing contexts by adding the following step before step 6:
@@ -431,14 +431,14 @@ To <dfn abstract-op>check a global object's embedder policy</dfn>, given a [=glo
     |owner policy|'s [=embedder policy/report only reporting endpoint=] is not null and
     |response policy|'s [=embedder policy/value=] is "`unsafe-none`", then [$queue coep worker
     violation|queue a Cross-Origin Embedder Policy vioalation on worker initialization$] with
-    |request|, |owner policy|'s [=embedder policy/report only reporting endpoint=] and |global|.
+    |request|, |owner policy|'s [=embedder policy/report only reporting endpoint=] and |owner|.
 
 4.  If |owner policy|'s [=embedder policy/value=] is "`require-corp`" and |child policy|'s
        [=embedder policy/value=] is "`unsafe-none`":
 
     1.  If |owner policy|'s [=embedder policy/reporting endpoint=] is not null, then [$queue coep
         worker violation|queue a Cross-Origin Embedder Policy vioalation on worker initialization$]
-        with |request|, |owner policy|'s [=embedder policy/reporting endpoint=] and |global|.
+        with |request|, |owner policy|'s [=embedder policy/reporting endpoint=] and |owner|.
 
     2.  Return "`blocked`".
 

--- a/index.bs
+++ b/index.bs
@@ -318,11 +318,15 @@ so, HTML is patched as follows:
     >     [$parse header|obtaining an embedder policy$] from |response|.
 
 5.  The [$run a worker$] algorithm sets the [=WorkerGlobalScope/embedder policy=] for
-    {{WorkerGlobalScope}} objects by adding a new step directly after Referrer Policy is initialized
+    {{WorkerGlobalScope}} objects by adding new steps directly after Referrer Policy is initialized
     in step 12.5:
 
     > 6.  Call [$initialize a global object's embedder policy from a response$] given
     >     <var ignore>worker global scope</var> and <var ignore>response</var>.
+    >
+    > 7.  If the result of [$cheking a global object's embedder policy$] given
+    >     <var ignore>worker global scope</var> and <var ignore>response</var> is "`blocked`", then
+    >     set |response| to a [=network error=].
 
 6.  The [$process a navigate fetch$] algorithm runs the [$cross-origin resource policy check$] for
     navigation for nested browsing contexts by adding the following step before step 6:
@@ -365,11 +369,9 @@ To <dfn abstract-op>initialize a global object's embedder policy from a response
 2.  Let |response policy| be the result of [$parse header|obtaining an embedder policy$] from
     |response|.
 
-3.  Run the steps corresponding to the first matching statement:
+3.  If |response|'s [=response/url=]'s [=url/scheme=] is a [=local scheme=]:
 
-    :   |response|'s [=response/url=]'s [=url/scheme=] is a [=local scheme=]
-    :   |global| is a {{DedicatedWorkerGlobalScope}}:
-    ::  1.  For each of the items in |global|'s [=WorkerGlobalScope/owner set=]:
+    1.  For each of the items in |global|'s [=WorkerGlobalScope/owner set=]:
 
             1.  If the item's [=/embedder policy=]'s [=embedder policy/value] is "`require-corp`",
                 then set |policy|'s [=embedder policy/value] to "`require-corp`".
@@ -386,12 +388,61 @@ To <dfn abstract-op>initialize a global object's embedder policy from a response
                 item's [=embedder policy/report only reporting endpoint=] is non-null, then
                 |policy|'s [=embedder policy/report only reporting endpoint=] to the item's
                 [=embedder policy/report only reporting endpoint=].
+4.  Otherwise:
 
-    :   |global| is a {{SharedWorkerGlobalScope}}:
-    :   |global| is a {{ServiceWorkerGlobalScope}}:
-    ::  1.   Set |policy| to |response policy|.
+    1.   Set |policy| to |response policy|.
 
-4.  Set |global|'s [=WorkerGlobalScope/embedder policy=] to |policy|.
+5.  Set |global|'s [=WorkerGlobalScope/embedder policy=] to |policy|.
+
+### Checking a global object's Embedder policy ### {#check-embedder-policy-for-global}
+<div algorithm="to check a global object's embedder policy">
+To <dfn abstract-op lt="queue coep worker violation">Queue a Cross-Origin Embedder Policy
+violation on worker initialization</dfn> given a [=request=] (|request|), a string (|endpoint|) and an
+[=environment settings object=] (|settings|), run the following steps:
+
+1.  Let |blocked url| be |request|'s [=request/URL=].
+
+    Note: This is not |request|'s [=request/current URL=] in order to avoid redirect
+    information leak.
+
+2.  Set |blocked url|'s [=url/username=] to the empty string, and its [=url/password=] to `null`.
+
+3.  Set |serialized blocked url| be the result of executing the
+    [URL serializer](https://url.spec.whatwg.org/#concept-url-serializer) on |blocked url|
+    with the |exclude fragment flag| set.
+
+4.  Let |body| be a new object containing the following properties with keys:
+
+    * key: "`type`", "`worker initializatoin`".
+    * key: "`blocked-url`", value: |serialized blocked url|.
+
+5.  [Queue](https://w3c.github.io/reporting/#queue-report) |body| as "`coep`" for
+    |endpoint| on |settings|.
+
+To <dfn abstract-op>check a global object's embedder policy</dfn>, given a [=global object=]
+(|global|), a [=environment settings object=] (|owner|) and a [=request=] (|request|), then
+
+1.  If |global| is a {{SharedWorkerGlobalScope}} or |global| is a {{ServiceWorkerGlobalScope}}, then
+    return "`allowed`".
+
+2.  Let |owner policy| be |owner|'s [=environment settings object/embedder policy=].
+
+3.  If |owner policy|'s [=embedder policy/report only value=] is "`require-corp`" and
+    |owner policy|'s [=embedder policy/report only reporting endpoint=] is not null and
+    |response policy|'s [=embedder policy/value=] is "`unsafe-none`", then [$queue coep worker
+    violation|queue a Cross-Origin Embedder Policy vioalation on worker initialization$] with
+    |request|, |owner policy|'s [=embedder policy/report only reporting endpoint=] and |global|.
+
+4.  If |owner policy|'s [=embedder policy/value=] is "`require-corp`" and |child policy|'s
+       [=embedder policy/value=] is "`unsafe-none`":
+
+    1.  If |owner policy|'s [=embedder policy/reporting endpoint=] is not null, then [$queue coep
+        worker violation|queue a Cross-Origin Embedder Policy vioalation on worker initialization$]
+        with |request|, |owner policy|'s [=embedder policy/reporting endpoint=] and |global|.
+
+    2.  Return "`blocked`".
+
+5.  Return "`allowed`".
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -395,7 +395,8 @@ To <dfn abstract-op>initialize a global object's embedder policy from a response
 5.  Set |global|'s [=WorkerGlobalScope/embedder policy=] to |policy|.
 
 ### Checking a global object's Embedder policy ### {#check-embedder-policy-for-global}
-<div algorithm="to check a global object's embedder policy">
+
+<div algorithm="to queu a coep worker violation">
 To <dfn abstract-op lt="queue coep worker violation">Queue a Cross-Origin Embedder Policy
 violation on worker initialization</dfn> given a [=request=] (|request|), a string (|endpoint|) and an
 [=environment settings object=] (|settings|), run the following steps:
@@ -419,6 +420,9 @@ violation on worker initialization</dfn> given a [=request=] (|request|), a stri
 5.  [Queue](https://w3c.github.io/reporting/#queue-report) |body| as "`coep`" for
     |endpoint| on |settings|.
 
+</div>
+
+<div algorithm="to check a global object's embedder policy">
 To <dfn abstract-op>check a global object's embedder policy</dfn>, given a [=global object=]
 (|global|), a [=environment settings object=] (|owner|) and a [=request=] (|request|), then
 

--- a/index.bs
+++ b/index.bs
@@ -325,8 +325,8 @@ so, HTML is patched as follows:
     >     <var ignore>worker global scope</var> and <var ignore>response</var>.
     >
     > 7.  If the result of [$check a global object's embedder policy$] given
-    >     <var ignore>request</var>, <var ignore>worker global scope</var> and
-    >     <var ignore>owner</var> is "`blocked`", then set |response| to a [=network error=].
+    >     <var ignore>worker global scope</var>, <var ignore>owner</var> and
+    >     <var ignore>request</var> is "`blocked`", then set |response| to a [=network error=].
 
 6.  The [$process a navigate fetch$] algorithm runs the [$cross-origin resource policy check$] for
     navigation for nested browsing contexts by adding the following step before step 6:

--- a/index.html
+++ b/index.html
@@ -1222,7 +1222,7 @@ Possible extra rowspan handling
 	}
 </style>
   <meta content="Bikeshed version 5721fde7f6b8111f662b83b678f9e181a9838206" name="generator">
-  <meta content="74b057c89085ca152a846edefd76197621d49308" name="document-revision">
+  <meta content="131306e40134c11cc3637c14f2f5a0dc8929b06e" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1699,8 +1699,7 @@ in step 12.5:</p>
        <li data-md>
         <p>Call <a data-link-type="abstract-op" href="#abstract-opdef-initialize-a-global-objects-embedder-policy-from-a-response" id="ref-for-abstract-opdef-initialize-a-global-objects-embedder-policy-from-a-response">initialize a global object’s embedder policy from a response</a> given <var>worker global scope</var> and <var>response</var>.</p>
        <li data-md>
-        <p>If the result of <a data-link-type="abstract-op">cheking a global object’s embedder policy</a> given <var>worker global scope</var> and <var>response</var> is "<code>blocked</code>", then
-set <var>response</var> to a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error">network error</a>.</p>
+        <p>If the result of <a data-link-type="abstract-op" href="#abstract-opdef-check-a-global-objects-embedder-policy" id="ref-for-abstract-opdef-check-a-global-objects-embedder-policy">check a global object’s embedder policy</a> given <var>request</var>, <var>worker global scope</var> and <var>owner</var> is "<code>blocked</code>", then set <var>response</var> to a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error">network error</a>.</p>
       </ol>
      </blockquote>
     <li data-md>
@@ -1798,7 +1797,7 @@ information leak.</p>
       <li data-md>
        <p><a href="https://w3c.github.io/reporting/#queue-report">Queue</a> <var>body</var> as "<code>coep</code>" for <var>endpoint</var> on <var>settings</var>.</p>
      </ol>
-     <p>To <dfn data-dfn-type="abstract-op" data-export id="abstract-opdef-check-a-global-objects-embedder-policy">check a global object’s embedder policy<a class="self-link" href="#abstract-opdef-check-a-global-objects-embedder-policy"></a></dfn>, given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①">global object</a> (<var>global</var>), a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object②">environment settings object</a> (<var>owner</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a> (<var>request</var>), then</p>
+     <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-check-a-global-objects-embedder-policy">check a global object’s embedder policy</dfn>, given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①">global object</a> (<var>global</var>), a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object②">environment settings object</a> (<var>owner</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a> (<var>request</var>), then</p>
      <ol>
       <li data-md>
        <p>If <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope" id="ref-for-sharedworkerglobalscope">SharedWorkerGlobalScope</a></code> or <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope">ServiceWorkerGlobalScope</a></code>, then
@@ -1806,12 +1805,12 @@ return "<code>allowed</code>".</p>
       <li data-md>
        <p>Let <var>owner policy</var> be <var>owner</var>’s <a data-link-type="dfn" href="#environment-settings-object-embedder-policy" id="ref-for-environment-settings-object-embedder-policy">embedder policy</a>.</p>
       <li data-md>
-       <p>If <var>owner policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-value" id="ref-for-embedder-policy-report-only-value①">report only value</a> is "<code>require-corp</code>" and <var>owner policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint④">report only reporting endpoint</a> is not null and <var>response policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value①">value</a> is "<code>unsafe-none</code>", then <a data-link-type="abstract-op" href="#abstract-opdef-queue-coep-worker-violation" id="ref-for-abstract-opdef-queue-coep-worker-violation">queue a Cross-Origin Embedder Policy vioalation on worker initialization</a> with <var>request</var>, <var>owner policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint⑤">report only reporting endpoint</a> and <var>global</var>.</p>
+       <p>If <var>owner policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-value" id="ref-for-embedder-policy-report-only-value①">report only value</a> is "<code>require-corp</code>" and <var>owner policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint④">report only reporting endpoint</a> is not null and <var>response policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value①">value</a> is "<code>unsafe-none</code>", then <a data-link-type="abstract-op" href="#abstract-opdef-queue-coep-worker-violation" id="ref-for-abstract-opdef-queue-coep-worker-violation">queue a Cross-Origin Embedder Policy vioalation on worker initialization</a> with <var>request</var>, <var>owner policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint⑤">report only reporting endpoint</a> and <var>owner</var>.</p>
       <li data-md>
        <p>If <var>owner policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value②">value</a> is "<code>require-corp</code>" and <var>child policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value③">value</a> is "<code>unsafe-none</code>":</p>
        <ol>
         <li data-md>
-         <p>If <var>owner policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint④">reporting endpoint</a> is not null, then <a data-link-type="abstract-op" href="#abstract-opdef-queue-coep-worker-violation" id="ref-for-abstract-opdef-queue-coep-worker-violation①">queue a Cross-Origin Embedder Policy vioalation on worker initialization</a> with <var>request</var>, <var>owner policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint⑤">reporting endpoint</a> and <var>global</var>.</p>
+         <p>If <var>owner policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint④">reporting endpoint</a> is not null, then <a data-link-type="abstract-op" href="#abstract-opdef-queue-coep-worker-violation" id="ref-for-abstract-opdef-queue-coep-worker-violation①">queue a Cross-Origin Embedder Policy vioalation on worker initialization</a> with <var>request</var>, <var>owner policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint⑤">reporting endpoint</a> and <var>owner</var>.</p>
         <li data-md>
          <p>Return "<code>blocked</code>".</p>
        </ol>
@@ -2745,6 +2744,12 @@ error-handling behavior.<a href="#issue-4328816a"> ↵ </a></div>
    <b><a href="#abstract-opdef-queue-coep-worker-violation">#abstract-opdef-queue-coep-worker-violation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-queue-coep-worker-violation">3.1.2. Checking a global object’s Embedder policy</a> <a href="#ref-for-abstract-opdef-queue-coep-worker-violation①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="abstract-opdef-check-a-global-objects-embedder-policy">
+   <b><a href="#abstract-opdef-check-a-global-objects-embedder-policy">#abstract-opdef-check-a-global-objects-embedder-policy</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-abstract-opdef-check-a-global-objects-embedder-policy">3.1. Integration with HTML</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-queue-coep-navigation-violation">

--- a/index.html
+++ b/index.html
@@ -1222,7 +1222,7 @@ Possible extra rowspan handling
 	}
 </style>
   <meta content="Bikeshed version 5721fde7f6b8111f662b83b678f9e181a9838206" name="generator">
-  <meta content="131306e40134c11cc3637c14f2f5a0dc8929b06e" name="document-revision">
+  <meta content="1038b545b4389184c188d6a73c96da3bd226c642" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1699,7 +1699,7 @@ in step 12.5:</p>
        <li data-md>
         <p>Call <a data-link-type="abstract-op" href="#abstract-opdef-initialize-a-global-objects-embedder-policy-from-a-response" id="ref-for-abstract-opdef-initialize-a-global-objects-embedder-policy-from-a-response">initialize a global object’s embedder policy from a response</a> given <var>worker global scope</var> and <var>response</var>.</p>
        <li data-md>
-        <p>If the result of <a data-link-type="abstract-op" href="#abstract-opdef-check-a-global-objects-embedder-policy" id="ref-for-abstract-opdef-check-a-global-objects-embedder-policy">check a global object’s embedder policy</a> given <var>request</var>, <var>worker global scope</var> and <var>owner</var> is "<code>blocked</code>", then set <var>response</var> to a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error">network error</a>.</p>
+        <p>If the result of <a data-link-type="abstract-op" href="#abstract-opdef-check-a-global-objects-embedder-policy" id="ref-for-abstract-opdef-check-a-global-objects-embedder-policy">check a global object’s embedder policy</a> given <var>worker global scope</var>, <var>owner</var> and <var>request</var> is "<code>blocked</code>", then set <var>response</var> to a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error">network error</a>.</p>
       </ol>
      </blockquote>
     <li data-md>

--- a/index.html
+++ b/index.html
@@ -1222,7 +1222,7 @@ Possible extra rowspan handling
 	}
 </style>
   <meta content="Bikeshed version 5721fde7f6b8111f662b83b678f9e181a9838206" name="generator">
-  <meta content="1038b545b4389184c188d6a73c96da3bd226c642" name="document-revision">
+  <meta content="e59fbaa66de7380dd89f0275eaa3cee25ec65b5e" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1422,7 +1422,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Cross-Origin Embedder Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2020-03-26">26 March 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2020-04-20">20 April 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>Issue Tracking:
@@ -1456,7 +1456,7 @@ pre .property::before, pre .property::after {
      <a href="#framework"><span class="secno">2</span> <span class="content">Framework</span></a>
      <ol class="toc">
       <li><a href="#COEP"><span class="secno">2.1</span> <span class="content">The <code>Cross-Origin-Embedder-Policy</code> HTTP Response Header</span></a>
-      <li><a href="#COEP①"><span class="secno">2.2</span> <span class="content">The <code>Cross-Origin-Embedder-Policy-Report-Only</code> HTTP Response Header</span></a>
+      <li><a href="#COEP-RO"><span class="secno">2.2</span> <span class="content">The <code>Cross-Origin-Embedder-Policy-Report-Only</code> HTTP Response Header</span></a>
       <li><a href="#parsing"><span class="secno">2.3</span> <span class="content">Parsing</span></a>
      </ol>
     <li>
@@ -1547,7 +1547,7 @@ represents the endpoint for violation reporting.</p>
    <p>In order to support forward-compatibility with as-yet-unknown request types, user agents MUST ignore
 this header if it contains an invalid value. Likewise, user agents MUST ignore this header if the
 value cannot be parsed as a <a data-link-type="grammar" href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.9" id="ref-for-section-3.9①"><code>sh-token</code></a>.</p>
-   <h3 class="heading settled" data-level="2.2" id="COEP①"><span class="secno">2.2. </span><span class="content">The <code>Cross-Origin-Embedder-Policy-Report-Only</code> HTTP Response Header</span><a class="self-link" href="#COEP①"></a></h3>
+   <h3 class="heading settled" data-level="2.2" id="COEP-RO"><span class="secno">2.2. </span><span class="content">The <code>Cross-Origin-Embedder-Policy-Report-Only</code> HTTP Response Header</span><a class="self-link" href="#COEP-RO"></a></h3>
    <p>The <dfn data-dfn-type="http-header" data-export id="http-headerdef-cross-origin-embedder-policy-report-only"><code>Cross-Origin-Embedder-Policy-Report-Only</code><a class="self-link" href="#http-headerdef-cross-origin-embedder-policy-report-only"></a></dfn> HTTP response header field
 allows a server to declare an embedder policy for a given document. It is a <a data-link-type="dfn" href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#" id="termref-for-①">Structured Header</a> whose value MUST be a <a data-link-type="dfn" href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.9" id="ref-for-section-3.9②">token</a>. <a data-link-type="biblio" href="#biblio-i-dietf-httpbis-header-structure">[I-D.ietf-httpbis-header-structure]</a> Its ABNF
 is:</p>
@@ -1774,14 +1774,14 @@ item’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-en
       <p>Set <var>global</var>’s <a data-link-type="dfn" href="#workerglobalscope-embedder-policy" id="ref-for-workerglobalscope-embedder-policy②">embedder policy</a> to <var>policy</var>.</p>
     </ol>
     <h4 class="heading settled" data-level="3.1.2" id="check-embedder-policy-for-global"><span class="secno">3.1.2. </span><span class="content">Checking a global object’s Embedder policy</span><a class="self-link" href="#check-embedder-policy-for-global"></a></h4>
-    <div class="algorithm" data-algorithm="to check a global object’s embedder policy">
+    <div class="algorithm" data-algorithm="to queu a coep worker violation">
       To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export data-lt="queue coep worker violation" id="abstract-opdef-queue-coep-worker-violation">Queue a Cross-Origin Embedder Policy
 violation on worker initialization</dfn> given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> (<var>request</var>), a string (<var>endpoint</var>) and an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object①">environment settings object</a> (<var>settings</var>), run the following steps: 
      <ol>
       <li data-md>
        <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">URL</a>.</p>
-       <p class="note" role="note"><span>Note:</span> This is not <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current URL</a> in order to avoid redirect
-information leak.</p>
+       <p class="note" role="note"><span>Note:</span> This is not <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current URL</a> in order to avoid leaking information
+about redirect targets (see https://w3c.github.io/webappsec-csp/#security-violation-reports).</p>
       <li data-md>
        <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password">password</a> to <code>null</code>.</p>
       <li data-md>
@@ -1790,14 +1790,16 @@ information leak.</p>
        <p>Let <var>body</var> be a new object containing the following properties with keys:</p>
        <ul>
         <li data-md>
-         <p>key: "<code>type</code>", "<code>worker initializatoin</code>".</p>
+         <p>key: "<code>type</code>", "<code>worker initialization</code>".</p>
         <li data-md>
          <p>key: "<code>blocked-url</code>", value: <var>serialized blocked url</var>.</p>
        </ul>
       <li data-md>
        <p><a href="https://w3c.github.io/reporting/#queue-report">Queue</a> <var>body</var> as "<code>coep</code>" for <var>endpoint</var> on <var>settings</var>.</p>
      </ol>
-     <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-check-a-global-objects-embedder-policy">check a global object’s embedder policy</dfn>, given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①">global object</a> (<var>global</var>), a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object②">environment settings object</a> (<var>owner</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a> (<var>request</var>), then</p>
+    </div>
+    <div class="algorithm" data-algorithm="to check a global object’s embedder policy">
+      To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-check-a-global-objects-embedder-policy">check a global object’s embedder policy</dfn>, given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①">global object</a> (<var>global</var>), a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object②">environment settings object</a> (<var>owner</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a> (<var>request</var>), then 
      <ol>
       <li data-md>
        <p>If <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope" id="ref-for-sharedworkerglobalscope">SharedWorkerGlobalScope</a></code> or <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope">ServiceWorkerGlobalScope</a></code>, then

--- a/index.html
+++ b/index.html
@@ -1221,7 +1221,8 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 576ef4f5126e3fb83bf07d9bbe1a64f99aa4944e" name="generator">
+  <meta content="Bikeshed version 5721fde7f6b8111f662b83b678f9e181a9838206" name="generator">
+  <meta content="74b057c89085ca152a846edefd76197621d49308" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1421,7 +1422,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Cross-Origin Embedder Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2020-03-19">19 March 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2020-03-26">26 March 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>Issue Tracking:
@@ -1465,7 +1466,8 @@ pre .property::before, pre .property::after {
        <a href="#integration-html"><span class="secno">3.1</span> <span class="content">Integration with HTML</span></a>
        <ol class="toc">
         <li><a href="#initialize-embedder-policy-for-global"><span class="secno">3.1.1</span> <span class="content">Initializing a global object’s Embedder policy</span></a>
-        <li><a href="#process-navigation-response"><span class="secno">3.1.2</span> <span class="content">Process a navigation response</span></a>
+        <li><a href="#check-embedder-policy-for-global"><span class="secno">3.1.2</span> <span class="content">Checking a global object’s Embedder policy</span></a>
+        <li><a href="#process-navigation-response"><span class="secno">3.1.3</span> <span class="content">Process a navigation response</span></a>
        </ol>
       <li>
        <a href="#integration-fetch"><span class="secno">3.2</span> <span class="content">Integration with Fetch</span></a>
@@ -1690,12 +1692,15 @@ Referrer Policy is initialized in step 6:</p>
       </ol>
      </blockquote>
     <li data-md>
-     <p>The <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker" id="ref-for-run-a-worker">run a worker</a> algorithm sets the <a data-link-type="dfn" href="#workerglobalscope-embedder-policy" id="ref-for-workerglobalscope-embedder-policy①">embedder policy</a> for <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope②">WorkerGlobalScope</a></code> objects by adding a new step directly after Referrer Policy is initialized
+     <p>The <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker" id="ref-for-run-a-worker">run a worker</a> algorithm sets the <a data-link-type="dfn" href="#workerglobalscope-embedder-policy" id="ref-for-workerglobalscope-embedder-policy①">embedder policy</a> for <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope②">WorkerGlobalScope</a></code> objects by adding new steps directly after Referrer Policy is initialized
 in step 12.5:</p>
      <blockquote>
       <ol start="6">
        <li data-md>
         <p>Call <a data-link-type="abstract-op" href="#abstract-opdef-initialize-a-global-objects-embedder-policy-from-a-response" id="ref-for-abstract-opdef-initialize-a-global-objects-embedder-policy-from-a-response">initialize a global object’s embedder policy from a response</a> given <var>worker global scope</var> and <var>response</var>.</p>
+       <li data-md>
+        <p>If the result of <a data-link-type="abstract-op">cheking a global object’s embedder policy</a> given <var>worker global scope</var> and <var>response</var> is "<code>blocked</code>", then
+set <var>response</var> to a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error">network error</a>.</p>
       </ol>
      </blockquote>
     <li data-md>
@@ -1715,7 +1720,7 @@ navigation for nested browsing contexts by adding the following step before step
          <li data-md>
           <p>Set <var>requestForCORPCheck</var>’s client to <var>parent</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active document</a>.</p>
          <li data-md>
-          <p>If the result of <a data-link-type="abstract-op" href="#abstract-opdef-cross-origin-resource-policy-check" id="ref-for-abstract-opdef-cross-origin-resource-policy-check①">cross-origin resource policy check</a> with <var>requestForCORPCheck</var> and <var>response</var> is <code>blocked</code>, then set <var>response</var> to a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error">network error</a>.</p>
+          <p>If the result of <a data-link-type="abstract-op" href="#abstract-opdef-cross-origin-resource-policy-check" id="ref-for-abstract-opdef-cross-origin-resource-policy-check①">cross-origin resource policy check</a> with <var>requestForCORPCheck</var> and <var>response</var> is <code>blocked</code>, then set <var>response</var> to a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error①">network error</a>.</p>
           <p class="note" role="note"><span>Note:</span> Here we’re running the <a data-link-type="abstract-op" href="#abstract-opdef-cross-origin-resource-policy-check" id="ref-for-abstract-opdef-cross-origin-resource-policy-check②">cross-origin resource policy check</a> against the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context" id="ref-for-parent-browsing-context①">parent browsing context</a> rather than <var>sourceBrowsingContext</var>. This is because we do
 care about the same-originness of the embedded content against the parent context, not
 the navigation source.</p>
@@ -1742,261 +1747,300 @@ embedder’s policy</a> algorithm returns "<code>Blocked</code>" when executed u
      <li data-md>
       <p>Let <var>response policy</var> be the result of <a data-link-type="abstract-op" href="#abstract-opdef-obtain-a-responses-embedder-policy" id="ref-for-abstract-opdef-obtain-a-responses-embedder-policy①">obtaining an embedder policy</a> from <var>response</var>.</p>
      <li data-md>
-      <p>Run the steps corresponding to the first matching statement:</p>
-      <dl>
-       <dt data-md><var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url">url</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme">local scheme</a>
-       <dt data-md><var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope" id="ref-for-dedicatedworkerglobalscope">DedicatedWorkerGlobalScope</a></code>:
-       <dd data-md>
+      <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url">url</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme">local scheme</a>:</p>
+      <ol>
+       <li data-md>
+        <p>For each of the items in <var>global</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set" id="ref-for-concept-WorkerGlobalScope-owner-set">owner set</a>:</p>
         <ol>
          <li data-md>
-          <p>For each of the items in <var>global</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set" id="ref-for-concept-WorkerGlobalScope-owner-set">owner set</a>:</p>
-          <ol>
-           <li data-md>
-            <p>If the item’s <a data-link-type="dfn" href="#embedder-policy" id="ref-for-embedder-policy⑤">embedder policy</a>'s [=embedder policy/value] is "<code>require-corp</code>",
+          <p>If the item’s <a data-link-type="dfn" href="#embedder-policy" id="ref-for-embedder-policy⑤">embedder policy</a>'s [=embedder policy/value] is "<code>require-corp</code>",
 then set <var>policy</var>’s [=embedder policy/value] to "<code>require-corp</code>".</p>
-           <li data-md>
-            <p>If <var>policy</var>’s [=embedder policy/reporting endpoint] is <code>null</code> and the item’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint①">reporting endpoint</a> is non-null, then <var>policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint②">reporting endpoint</a> to the item’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint③">reporting endpoint</a>.</p>
-           <li data-md>
-            <p>If the item’s <a data-link-type="dfn" href="#embedder-policy" id="ref-for-embedder-policy⑥">embedder policy</a>'s [=embedder policy/report only value] is
-"<code>require-corp</code>", then set <var>policy</var>’s [=embedder policy/value] to "<code>require-corp</code>".</p>
-           <li data-md>
-            <p>If <var>policy</var>’s [=embedder policy/report only reporting endpoint] is <code>null</code> and the
-item’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint①">report only reporting endpoint</a> is non-null, then <var>policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint②">report only reporting endpoint</a> to the item’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint③">report only reporting endpoint</a>.</p>
-          </ol>
-        </ol>
-       <dt data-md><var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope" id="ref-for-sharedworkerglobalscope">SharedWorkerGlobalScope</a></code>:
-       <dt data-md><var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope">ServiceWorkerGlobalScope</a></code>:
-       <dd data-md>
-        <ol>
          <li data-md>
-          <p>Set <var>policy</var> to <var>response policy</var>.</p>
+          <p>If <var>policy</var>’s [=embedder policy/reporting endpoint] is <code>null</code> and the item’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint①">reporting endpoint</a> is non-null, then <var>policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint②">reporting endpoint</a> to the item’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint③">reporting endpoint</a>.</p>
+         <li data-md>
+          <p>If the item’s <a data-link-type="dfn" href="#embedder-policy" id="ref-for-embedder-policy⑥">embedder policy</a>'s [=embedder policy/report only value] is
+"<code>require-corp</code>", then set <var>policy</var>’s [=embedder policy/value] to "<code>require-corp</code>".</p>
+         <li data-md>
+          <p>If <var>policy</var>’s [=embedder policy/report only reporting endpoint] is <code>null</code> and the
+item’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint①">report only reporting endpoint</a> is non-null, then <var>policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint②">report only reporting endpoint</a> to the item’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint③">report only reporting endpoint</a>.</p>
         </ol>
-      </dl>
+      </ol>
+     <li data-md>
+      <p>Otherwise:</p>
+      <ol>
+       <li data-md>
+        <p>Set <var>policy</var> to <var>response policy</var>.</p>
+      </ol>
      <li data-md>
       <p>Set <var>global</var>’s <a data-link-type="dfn" href="#workerglobalscope-embedder-policy" id="ref-for-workerglobalscope-embedder-policy②">embedder policy</a> to <var>policy</var>.</p>
     </ol>
-   </div>
-   <h4 class="heading settled" data-level="3.1.2" id="process-navigation-response"><span class="secno">3.1.2. </span><span class="content">Process a navigation response</span><a class="self-link" href="#process-navigation-response"></a></h4>
-   <div class="algorithm" data-algorithm="process a navigation response">
-     If a document’s <a data-link-type="dfn" href="#document-embedder-policy" id="ref-for-document-embedder-policy⑥">embedder policy</a> is "<code>require-corp</code>", then any document it embeds in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context">nested browsing context</a> must positively assert a "<code>require-corp</code>" <a data-link-type="dfn" href="#embedder-policy" id="ref-for-embedder-policy⑦">embedder policy</a> (see <a href="#cascade-vs-require">§ 4.3 Cascading vs. requiring embedder policies</a>). 
-    <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export data-lt="queue coep navigation violation" id="abstract-opdef-queue-coep-navigation-violation">Queue a Cross-Origin Embedder Policy
-violation on navigation</dfn> given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> (<var>request</var>), a string (<var>endpoint</var>) and an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object①">environment settings object</a> (<var>settings</var>), run the following steps:</p>
-    <ol>
-     <li data-md>
-      <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">URL</a>.</p>
-      <p class="note" role="note"><span>Note:</span> This is not <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current URL</a> in order to avoid redirect
-information leak.</p>
-     <li data-md>
-      <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password">password</a> to <code>null</code>.</p>
-     <li data-md>
-      <p>Set <var>serialized blocked url</var> be the result of executing the <a href="https://url.spec.whatwg.org/#concept-url-serializer">URL serializer</a> on <var>blocked url</var> with the <var>exclude fragment flag</var> set.</p>
-     <li data-md>
-      <p>Let <var>body</var> be a new object containing the following properties with keys:</p>
-      <ul>
-       <li data-md>
-        <p>key: "<code>type</code>", "<code>navigation</code>".</p>
-       <li data-md>
-        <p>key: "<code>blocked-url</code>", value: <var>serialized blocked url</var>.</p>
-      </ul>
-     <li data-md>
-      <p><a href="https://w3c.github.io/reporting/#queue-report">Queue</a> <var>body</var> as "<code>coep-navigation</code>" for <var>endpoint</var> on <var>settings</var>.</p>
-    </ol>
-    <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export data-lt="process navigation response" id="abstract-opdef-process-navigation-response">check a navigation response’s adherence to its
-embedder’s policy</dfn> given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a> (<var>response</var>), and a target <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing context</a> (<var>target</var>), execute the following steps, which will return "<code>Allowed</code>" or
-"<code>Blocked</code>" as appropriate:</p>
-    <ol>
-     <li data-md>
-      <p>Return "<code>Allowed</code>" if <var>target</var> is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#child-browsing-context" id="ref-for-child-browsing-context①">child browsing context</a>.</p>
-     <li data-md>
-      <p>Let <var>response policy</var> be the result of <a data-link-type="abstract-op" href="#abstract-opdef-obtain-a-responses-embedder-policy" id="ref-for-abstract-opdef-obtain-a-responses-embedder-policy②">obtaining an embedder policy</a> from <var>response</var>.</p>
-     <li data-md>
-      <p>Let <var>parent policy</var> be <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document">container document</a>'s <a data-link-type="dfn" href="#document-embedder-policy" id="ref-for-document-embedder-policy⑦">embedder policy</a>.</p>
-     <li data-md>
-      <p>If <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-value" id="ref-for-embedder-policy-report-only-value①">report only value</a> is "<code>require-corp</code>" and <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint④">report only reporting endpoint</a> is not null and <var>response policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value①">value</a> is "<code>unsafe-none</code>", then <a data-link-type="abstract-op" href="#abstract-opdef-queue-coep-navigation-violation" id="ref-for-abstract-opdef-queue-coep-navigation-violation">queue a Cross-Origin Embedder Policy vioalation on navigation</a> with <var>request</var>, <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint⑤">report only reporting endpoint</a> and <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document①">container document</a>.</p>
-     <li data-md>
-      <p>If <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value②">value</a> is "<code>require-corp</code>" and <var>child policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value③">value</a> is "<code>unsafe-none</code>":</p>
-      <ol>
-       <li data-md>
-        <p>If <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint④">reporting endpoint</a> is not null, then <a data-link-type="abstract-op" href="#abstract-opdef-queue-coep-navigation-violation" id="ref-for-abstract-opdef-queue-coep-navigation-violation①">queue a Cross-Origin Embedder Policy vioalation on navigation</a> with <var>request</var>, <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint⑤">reporting endpoint</a> and <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document②">container document</a>.</p>
-       <li data-md>
-        <p>Return "<code>Blocked</code>".</p>
-      </ol>
-     <li data-md>
-      <p>Return "<code>Allowed</code>".</p>
-    </ol>
-   </div>
-   <h3 class="heading settled" data-level="3.2" id="integration-fetch"><span class="secno">3.2. </span><span class="content">Integration with Fetch</span><a class="self-link" href="#integration-fetch"></a></h3>
-   <p>When fetching resources, user agents should examine both the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>'s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client">client</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-reserved-client" id="ref-for-concept-request-reserved-client">reserved client</a> to determine the applicable <a data-link-type="dfn" href="#embedder-policy" id="ref-for-embedder-policy⑧">embedder policy</a>, and apply any constraints that policy expresses
-to incoming responses. To do so, Fetch is patched as follows:</p>
-   <ol>
-    <li data-md>
-     <p>The <code>Cross-Origin-Resource-Policy</code> grammar is extended to include a "<code>cross-origin</code>" value.</p>
-    <li data-md>
-     <p>The <a data-link-type="abstract-op" href="#abstract-opdef-cross-origin-resource-policy-check" id="ref-for-abstract-opdef-cross-origin-resource-policy-check③">cross-origin resource policy check</a> is rewritten to take the <a data-link-type="dfn" href="#embedder-policy" id="ref-for-embedder-policy⑨">embedder policy</a> into
-account, and to cover some <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#navigation-request" id="ref-for-navigation-request①">navigation requests</a> in addition to <code>no-cors</code> requests.</p>
-   </ol>
-   <h4 class="heading settled" data-level="3.2.1" id="corp-check"><span class="secno">3.2.1. </span><span class="content">Cross-Origin Resource Policy Checks</span><a class="self-link" href="#corp-check"></a></h4>
-   <p>To perform a <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-cross-origin-resource-policy-internal-check">cross-origin resource policy internal check</dfn> given a string
-(<var>embedder policy value</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③">response</a> (<var>response</var>), run these
-steps:</p>
-   <ol>
-    <li data-md>
-     <p>Return <code>allowed</code> if <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-mode" id="ref-for-concept-request-mode">mode</a> is "<code>same-origin</code>", "<code>cors</code>", or "<code>websocket</code>".</p>
-    <li data-md>
-     <p>If <var>request</var>’s mode is "<code>navigate</code>":</p>
+    <h4 class="heading settled" data-level="3.1.2" id="check-embedder-policy-for-global"><span class="secno">3.1.2. </span><span class="content">Checking a global object’s Embedder policy</span><a class="self-link" href="#check-embedder-policy-for-global"></a></h4>
+    <div class="algorithm" data-algorithm="to check a global object’s embedder policy">
+      To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export data-lt="queue coep worker violation" id="abstract-opdef-queue-coep-worker-violation">Queue a Cross-Origin Embedder Policy
+violation on worker initialization</dfn> given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> (<var>request</var>), a string (<var>endpoint</var>) and an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object①">environment settings object</a> (<var>settings</var>), run the following steps: 
      <ol>
       <li data-md>
-       <p class="assertion">ASSERT: This algorithm will only be called when <var>request</var> targets a nested
-browsing context; therefore, its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination">destination</a> is either "<code>frame</code>",
-"<code>iframe</code>", "<code>embed</code>", or "<code>object</code>".</p>
-       <p class="note" role="note"><span>Note:</span> This relies on <a href="https://github.com/whatwg/fetch/pull/948">whatwg/fetch/#948</a>.</p>
+       <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">URL</a>.</p>
+       <p class="note" role="note"><span>Note:</span> This is not <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current URL</a> in order to avoid redirect
+information leak.</p>
       <li data-md>
-       <p>If <var>embedder policy value</var> is "<code>unsafe-none</code>", then return <code>allowed</code>.</p>
-     </ol>
-    <li data-md>
-     <p>Let <var>policy</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-list-get" id="ref-for-concept-header-list-get">getting</a> <code>Cross-Origin-Resource-Policy</code> from <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list">header list</a>.</p>
-    <li data-md>
-     <p>If <var>policy</var> is <code>null</code> and <var>embedder policy value</var> is "<code>require-corp</code>",
-then set <var>policy</var> to "<code>same-origin</code>".</p>
-    <li data-md>
-     <p>Switch on <var>policy</var> and run the associated steps:</p>
-     <dl>
-      <dt data-md><code>null</code>
-      <dt data-md><code>cross-origin</code>
-      <dd data-md>
-       <p>Return <code>allowed</code>.</p>
-      <dt data-md><code>same-origin</code>
-      <dd data-md>
-       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin">origin</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin" id="ref-for-same-origin">same origin</a> with <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current URL</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin">origin</a>, then return <code>allowed</code>.</p>
-       <p>Otherwise, return <code>blocked</code>.</p>
-      <dt data-md><code>same-site</code>
-      <dd data-md>
-       <p>If both of the following statements are true, then return <code>allowed</code>:</p>
+       <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password">password</a> to <code>null</code>.</p>
+      <li data-md>
+       <p>Set <var>serialized blocked url</var> be the result of executing the <a href="https://url.spec.whatwg.org/#concept-url-serializer">URL serializer</a> on <var>blocked url</var> with the <var>exclude fragment flag</var> set.</p>
+      <li data-md>
+       <p>Let <var>body</var> be a new object containing the following properties with keys:</p>
        <ul>
         <li data-md>
-         <p><var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-host" id="ref-for-concept-origin-host">host</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-site" id="ref-for-same-site">same site</a> with <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url②">current URL</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-host" id="ref-for-concept-origin-host①">host</a>.</p>
+         <p>key: "<code>type</code>", "<code>worker initializatoin</code>".</p>
         <li data-md>
-         <p><var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin②">origin</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme">scheme</a> is "<code>https</code>", or <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-https-state" id="ref-for-concept-response-https-state">HTTPS state</a> is "<code>none</code>".</p>
+         <p>key: "<code>blocked-url</code>", value: <var>serialized blocked url</var>.</p>
        </ul>
-       <p>Otherwise, return <code>blocked</code>.</p>
-       <p class="note" role="note"><span>Note:</span> <code>Cross-Origin-Resource-Policy: same-site</code> does not consider a response delivered
-via a secure transport to match a non-secure requesting origin, even if their hosts are
-otherwise <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-site" id="ref-for-same-site①">same site</a>. Securely-transported responses will only match a
-securely-transported initiator.</p>
-      <dt data-md>Otherwise
-      <dd data-md>
-       <p>Return <code>allowed</code>.</p>
-       <p class="issue" id="issue-4328816a"><a class="self-link" href="#issue-4328816a"></a> Anne suggested that we ought to fail closed instead in the presence of COEP in <a href="https://github.com/whatwg/fetch/pull/893#discussion_r274867414">a comment on the relevant PR</a>.
-That seems reasonable to me, if we can get some changes into CORP along the lines of <a href="https://github.com/whatwg/fetch/issues/760">whatwg/fetch#760</a>, as they seem like useful
-extensions, and I think it’ll be more difficult to ship them after inverting the
-error-handling behavior.</p>
-     </dl>
-   </ol>
-   <p>To perform a <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-cross-origin-resource-policy-check">cross-origin resource policy check</dfn> given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④">response</a> (<var>response</var>), run these steps:</p>
-   <ol>
-    <li data-md>
-     <p>Let <var>embedder policy</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①">client</a>'s <a data-link-type="dfn" href="#environment-settings-object-embedder-policy" id="ref-for-environment-settings-object-embedder-policy">embedder policy</a>.</p>
-    <li data-md>
-     <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-reserved-client" id="ref-for-concept-request-reserved-client①">reserved client</a> is not <code>null</code>, then set <var>embedder policy</var> to a new <a data-link-type="dfn" href="#embedder-policy" id="ref-for-embedder-policy①⓪">embedder policy</a>.</p>
-    <li data-md>
-     <p>If <var>embedder policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint⑥">report only reporting endpoint</a> is not <code>null</code> and the
-result of running [$cross-origin resource policy internal check] with <a data-link-type="dfn" href="#embedder-policy-report-only-value" id="ref-for-embedder-policy-report-only-value②">report only value</a>, <var>request</var> and <var>response</var> is <code>blocked</code>, then run these
-steps:</p>
+      <li data-md>
+       <p><a href="https://w3c.github.io/reporting/#queue-report">Queue</a> <var>body</var> as "<code>coep</code>" for <var>endpoint</var> on <var>settings</var>.</p>
+     </ol>
+     <p>To <dfn data-dfn-type="abstract-op" data-export id="abstract-opdef-check-a-global-objects-embedder-policy">check a global object’s embedder policy<a class="self-link" href="#abstract-opdef-check-a-global-objects-embedder-policy"></a></dfn>, given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①">global object</a> (<var>global</var>), a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object②">environment settings object</a> (<var>owner</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a> (<var>request</var>), then</p>
+     <ol>
+      <li data-md>
+       <p>If <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope" id="ref-for-sharedworkerglobalscope">SharedWorkerGlobalScope</a></code> or <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope">ServiceWorkerGlobalScope</a></code>, then
+return "<code>allowed</code>".</p>
+      <li data-md>
+       <p>Let <var>owner policy</var> be <var>owner</var>’s <a data-link-type="dfn" href="#environment-settings-object-embedder-policy" id="ref-for-environment-settings-object-embedder-policy">embedder policy</a>.</p>
+      <li data-md>
+       <p>If <var>owner policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-value" id="ref-for-embedder-policy-report-only-value①">report only value</a> is "<code>require-corp</code>" and <var>owner policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint④">report only reporting endpoint</a> is not null and <var>response policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value①">value</a> is "<code>unsafe-none</code>", then <a data-link-type="abstract-op" href="#abstract-opdef-queue-coep-worker-violation" id="ref-for-abstract-opdef-queue-coep-worker-violation">queue a Cross-Origin Embedder Policy vioalation on worker initialization</a> with <var>request</var>, <var>owner policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint⑤">report only reporting endpoint</a> and <var>global</var>.</p>
+      <li data-md>
+       <p>If <var>owner policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value②">value</a> is "<code>require-corp</code>" and <var>child policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value③">value</a> is "<code>unsafe-none</code>":</p>
+       <ol>
+        <li data-md>
+         <p>If <var>owner policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint④">reporting endpoint</a> is not null, then <a data-link-type="abstract-op" href="#abstract-opdef-queue-coep-worker-violation" id="ref-for-abstract-opdef-queue-coep-worker-violation①">queue a Cross-Origin Embedder Policy vioalation on worker initialization</a> with <var>request</var>, <var>owner policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint⑤">reporting endpoint</a> and <var>global</var>.</p>
+        <li data-md>
+         <p>Return "<code>blocked</code>".</p>
+       </ol>
+      <li data-md>
+       <p>Return "<code>allowed</code>".</p>
+     </ol>
+    </div>
+    <h4 class="heading settled" data-level="3.1.3" id="process-navigation-response"><span class="secno">3.1.3. </span><span class="content">Process a navigation response</span><a class="self-link" href="#process-navigation-response"></a></h4>
+    <div class="algorithm" data-algorithm="process a navigation response">
+      If a document’s <a data-link-type="dfn" href="#document-embedder-policy" id="ref-for-document-embedder-policy⑥">embedder policy</a> is "<code>require-corp</code>", then any document it embeds in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context">nested browsing context</a> must positively assert a "<code>require-corp</code>" <a data-link-type="dfn" href="#embedder-policy" id="ref-for-embedder-policy⑦">embedder policy</a> (see <a href="#cascade-vs-require">§ 4.3 Cascading vs. requiring embedder policies</a>). 
+     <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export data-lt="queue coep navigation violation" id="abstract-opdef-queue-coep-navigation-violation">Queue a Cross-Origin Embedder Policy
+violation on navigation</dfn> given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a> (<var>request</var>), a string (<var>endpoint</var>) and an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object③">environment settings object</a> (<var>settings</var>), run the following steps:</p>
      <ol>
       <li data-md>
        <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①">URL</a>.</p>
+       <p class="note" role="note"><span>Note:</span> This is not <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current URL</a> in order to avoid redirect
+information leak.</p>
       <li data-md>
        <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username①">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password①">password</a> to <code>null</code>.</p>
       <li data-md>
-       <p>Set <var>serialized blocked url</var> be the result of executing the <a href="https://url.spec.whatwg.org/#concept-url-serializer">URL serializer</a> on <var>blocked url</var> with
-the <var>exclude fragment flag</var> set.</p>
+       <p>Set <var>serialized blocked url</var> be the result of executing the <a href="https://url.spec.whatwg.org/#concept-url-serializer">URL serializer</a> on <var>blocked url</var> with the <var>exclude fragment flag</var> set.</p>
       <li data-md>
        <p>Let <var>body</var> be a new object containing the following properties with keys:</p>
        <ul>
         <li data-md>
-         <p>key: "<code>type</code>", value: "<code>CORP</code>".</p>
+         <p>key: "<code>type</code>", "<code>navigation</code>".</p>
         <li data-md>
          <p>key: "<code>blocked-url</code>", value: <var>serialized blocked url</var>.</p>
        </ul>
       <li data-md>
-       <p><a href="https://w3c.github.io/reporting/#queue-report">Queue</a> <var>body</var> as "<code>coep</code>" for <var>embedder policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint⑦">report only reporting endpoint</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client②">client</a>.</p>
+       <p><a href="https://w3c.github.io/reporting/#queue-report">Queue</a> <var>body</var> as "<code>coep-navigation</code>" for <var>endpoint</var> on <var>settings</var>.</p>
      </ol>
-    <li data-md>
-     <p>Let <var>result</var> be the result of running <a data-link-type="abstract-op" href="#abstract-opdef-cross-origin-resource-policy-internal-check" id="ref-for-abstract-opdef-cross-origin-resource-policy-internal-check">cross-origin resource policy internal check</a> with <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value④">value</a>, <var>request</var> and <var>response</var>.</p>
-    <li data-md>
-     <p>If <var>embedder policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint⑥">reporting endpoint</a> is not <code>null</code> and <var>result</var> is <code>blocked</code>, then run these steps:</p>
+     <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export data-lt="process navigation response" id="abstract-opdef-process-navigation-response">check a navigation response’s adherence to its
+embedder’s policy</dfn> given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a> (<var>response</var>), and a target <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing context</a> (<var>target</var>), execute the following steps, which will return "<code>Allowed</code>" or
+"<code>Blocked</code>" as appropriate:</p>
      <ol>
       <li data-md>
-       <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">URL</a>.</p>
+       <p>Return "<code>Allowed</code>" if <var>target</var> is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#child-browsing-context" id="ref-for-child-browsing-context①">child browsing context</a>.</p>
       <li data-md>
-       <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username②">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password②">password</a> to <code>null</code>.</p>
+       <p>Let <var>response policy</var> be the result of <a data-link-type="abstract-op" href="#abstract-opdef-obtain-a-responses-embedder-policy" id="ref-for-abstract-opdef-obtain-a-responses-embedder-policy②">obtaining an embedder policy</a> from <var>response</var>.</p>
       <li data-md>
-       <p>Set <var>serialized blocked url</var> be the result of executing the <a href="https://url.spec.whatwg.org/#concept-url-serializer">URL serializer</a> on <var>blocked url</var> with
-the <var>exclude fragment flag</var> set.</p>
+       <p>Let <var>parent policy</var> be <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document">container document</a>'s <a data-link-type="dfn" href="#document-embedder-policy" id="ref-for-document-embedder-policy⑦">embedder policy</a>.</p>
       <li data-md>
-       <p>Let <var>body</var> be a new object containing the following properties with keys:</p>
-       <ul>
+       <p>If <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-value" id="ref-for-embedder-policy-report-only-value②">report only value</a> is "<code>require-corp</code>" and <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint⑥">report only reporting endpoint</a> is not null and <var>response policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value④">value</a> is "<code>unsafe-none</code>", then <a data-link-type="abstract-op" href="#abstract-opdef-queue-coep-navigation-violation" id="ref-for-abstract-opdef-queue-coep-navigation-violation">queue a Cross-Origin Embedder Policy vioalation on navigation</a> with <var>request</var>, <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint⑦">report only reporting endpoint</a> and <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document①">container document</a>.</p>
+      <li data-md>
+       <p>If <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value⑤">value</a> is "<code>require-corp</code>" and <var>child policy</var>’s <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value⑥">value</a> is "<code>unsafe-none</code>":</p>
+       <ol>
         <li data-md>
-         <p>key: "<code>type</code>", value: "<code>CORP</code>".</p>
+         <p>If <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint⑥">reporting endpoint</a> is not null, then <a data-link-type="abstract-op" href="#abstract-opdef-queue-coep-navigation-violation" id="ref-for-abstract-opdef-queue-coep-navigation-violation①">queue a Cross-Origin Embedder Policy vioalation on navigation</a> with <var>request</var>, <var>parent policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint⑦">reporting endpoint</a> and <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document②">container document</a>.</p>
         <li data-md>
-         <p>key: "<code>blocked-url</code>", value: <var>serialized blocked url</var>.</p>
-       </ul>
+         <p>Return "<code>Blocked</code>".</p>
+       </ol>
       <li data-md>
-       <p><a href="https://w3c.github.io/reporting/#queue-report">Queue</a> <var>body</var> as "<code>coep</code>" for <var>embedder policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint⑦">reporting endpoint</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client③">client</a>.</p>
+       <p>Return "<code>Allowed</code>".</p>
      </ol>
-    <li data-md>
-     <p>Return <var>result</var>.</p>
-   </ol>
-   <h3 class="heading settled" data-level="3.3" id="integration-sw"><span class="secno">3.3. </span><span class="content">Integration with Service Worker</span><a class="self-link" href="#integration-sw"></a></h3>
-   <p>In https://w3c.github.io/ServiceWorker/#dom-fetchevent-respondwith, replace 10.1 with the following
+    </div>
+    <h3 class="heading settled" data-level="3.2" id="integration-fetch"><span class="secno">3.2. </span><span class="content">Integration with Fetch</span><a class="self-link" href="#integration-fetch"></a></h3>
+    <p>When fetching resources, user agents should examine both the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④">request</a>'s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client">client</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-reserved-client" id="ref-for-concept-request-reserved-client">reserved client</a> to determine the applicable <a data-link-type="dfn" href="#embedder-policy" id="ref-for-embedder-policy⑧">embedder policy</a>, and apply any constraints that policy expresses
+to incoming responses. To do so, Fetch is patched as follows:</p>
+    <ol>
+     <li data-md>
+      <p>The <code>Cross-Origin-Resource-Policy</code> grammar is extended to include a "<code>cross-origin</code>" value.</p>
+     <li data-md>
+      <p>The <a data-link-type="abstract-op" href="#abstract-opdef-cross-origin-resource-policy-check" id="ref-for-abstract-opdef-cross-origin-resource-policy-check③">cross-origin resource policy check</a> is rewritten to take the <a data-link-type="dfn" href="#embedder-policy" id="ref-for-embedder-policy⑨">embedder policy</a> into
+account, and to cover some <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#navigation-request" id="ref-for-navigation-request①">navigation requests</a> in addition to <code>no-cors</code> requests.</p>
+    </ol>
+    <h4 class="heading settled" data-level="3.2.1" id="corp-check"><span class="secno">3.2.1. </span><span class="content">Cross-Origin Resource Policy Checks</span><a class="self-link" href="#corp-check"></a></h4>
+    <p>To perform a <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-cross-origin-resource-policy-internal-check">cross-origin resource policy internal check</dfn> given a string
+(<var>embedder policy value</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③">response</a> (<var>response</var>), run these
+steps:</p>
+    <ol>
+     <li data-md>
+      <p>Return <code>allowed</code> if <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-mode" id="ref-for-concept-request-mode">mode</a> is "<code>same-origin</code>", "<code>cors</code>", or "<code>websocket</code>".</p>
+     <li data-md>
+      <p>If <var>request</var>’s mode is "<code>navigate</code>":</p>
+      <ol>
+       <li data-md>
+        <p class="assertion">ASSERT: This algorithm will only be called when <var>request</var> targets a nested
+browsing context; therefore, its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination">destination</a> is either "<code>frame</code>",
+"<code>iframe</code>", "<code>embed</code>", or "<code>object</code>".</p>
+        <p class="note" role="note"><span>Note:</span> This relies on <a href="https://github.com/whatwg/fetch/pull/948">whatwg/fetch/#948</a>.</p>
+       <li data-md>
+        <p>If <var>embedder policy value</var> is "<code>unsafe-none</code>", then return <code>allowed</code>.</p>
+      </ol>
+     <li data-md>
+      <p>Let <var>policy</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-list-get" id="ref-for-concept-header-list-get">getting</a> <code>Cross-Origin-Resource-Policy</code> from <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list">header list</a>.</p>
+     <li data-md>
+      <p>If <var>policy</var> is <code>null</code> and <var>embedder policy value</var> is "<code>require-corp</code>",
+then set <var>policy</var> to "<code>same-origin</code>".</p>
+     <li data-md>
+      <p>Switch on <var>policy</var> and run the associated steps:</p>
+      <dl>
+       <dt data-md><code>null</code>
+       <dt data-md><code>cross-origin</code>
+       <dd data-md>
+        <p>Return <code>allowed</code>.</p>
+       <dt data-md><code>same-origin</code>
+       <dd data-md>
+        <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin">origin</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin" id="ref-for-same-origin">same origin</a> with <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url②">current URL</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin">origin</a>, then return <code>allowed</code>.</p>
+        <p>Otherwise, return <code>blocked</code>.</p>
+       <dt data-md><code>same-site</code>
+       <dd data-md>
+        <p>If both of the following statements are true, then return <code>allowed</code>:</p>
+        <ul>
+         <li data-md>
+          <p><var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-host" id="ref-for-concept-origin-host">host</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-site" id="ref-for-same-site">same site</a> with <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url③">current URL</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-host" id="ref-for-concept-origin-host①">host</a>.</p>
+         <li data-md>
+          <p><var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin②">origin</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme">scheme</a> is "<code>https</code>", or <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-https-state" id="ref-for-concept-response-https-state">HTTPS state</a> is "<code>none</code>".</p>
+        </ul>
+        <p>Otherwise, return <code>blocked</code>.</p>
+        <p class="note" role="note"><span>Note:</span> <code>Cross-Origin-Resource-Policy: same-site</code> does not consider a response delivered
+via a secure transport to match a non-secure requesting origin, even if their hosts are
+otherwise <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-site" id="ref-for-same-site①">same site</a>. Securely-transported responses will only match a
+securely-transported initiator.</p>
+       <dt data-md>Otherwise
+       <dd data-md>
+        <p>Return <code>allowed</code>.</p>
+        <p class="issue" id="issue-4328816a"><a class="self-link" href="#issue-4328816a"></a> Anne suggested that we ought to fail closed instead in the presence of COEP in <a href="https://github.com/whatwg/fetch/pull/893#discussion_r274867414">a comment on the relevant PR</a>.
+That seems reasonable to me, if we can get some changes into CORP along the lines of <a href="https://github.com/whatwg/fetch/issues/760">whatwg/fetch#760</a>, as they seem like useful
+extensions, and I think it’ll be more difficult to ship them after inverting the
+error-handling behavior.</p>
+      </dl>
+    </ol>
+    <p>To perform a <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-cross-origin-resource-policy-check">cross-origin resource policy check</dfn> given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④">response</a> (<var>response</var>), run these steps:</p>
+    <ol>
+     <li data-md>
+      <p>Let <var>embedder policy</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①">client</a>'s <a data-link-type="dfn" href="#environment-settings-object-embedder-policy" id="ref-for-environment-settings-object-embedder-policy①">embedder policy</a>.</p>
+     <li data-md>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-reserved-client" id="ref-for-concept-request-reserved-client①">reserved client</a> is not <code>null</code>, then set <var>embedder policy</var> to a new <a data-link-type="dfn" href="#embedder-policy" id="ref-for-embedder-policy①⓪">embedder policy</a>.</p>
+     <li data-md>
+      <p>If <var>embedder policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint⑧">report only reporting endpoint</a> is not <code>null</code> and the
+result of running [$cross-origin resource policy internal check] with <a data-link-type="dfn" href="#embedder-policy-report-only-value" id="ref-for-embedder-policy-report-only-value③">report only value</a>, <var>request</var> and <var>response</var> is <code>blocked</code>, then run these
+steps:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">URL</a>.</p>
+       <li data-md>
+        <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username②">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password②">password</a> to <code>null</code>.</p>
+       <li data-md>
+        <p>Set <var>serialized blocked url</var> be the result of executing the <a href="https://url.spec.whatwg.org/#concept-url-serializer">URL serializer</a> on <var>blocked url</var> with
+the <var>exclude fragment flag</var> set.</p>
+       <li data-md>
+        <p>Let <var>body</var> be a new object containing the following properties with keys:</p>
+        <ul>
+         <li data-md>
+          <p>key: "<code>type</code>", value: "<code>CORP</code>".</p>
+         <li data-md>
+          <p>key: "<code>blocked-url</code>", value: <var>serialized blocked url</var>.</p>
+        </ul>
+       <li data-md>
+        <p><a href="https://w3c.github.io/reporting/#queue-report">Queue</a> <var>body</var> as "<code>coep</code>" for <var>embedder policy</var>’s <a data-link-type="dfn" href="#embedder-policy-report-only-reporting-endpoint" id="ref-for-embedder-policy-report-only-reporting-endpoint⑨">report only reporting endpoint</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client②">client</a>.</p>
+      </ol>
+     <li data-md>
+      <p>Let <var>result</var> be the result of running <a data-link-type="abstract-op" href="#abstract-opdef-cross-origin-resource-policy-internal-check" id="ref-for-abstract-opdef-cross-origin-resource-policy-internal-check">cross-origin resource policy internal check</a> with <a data-link-type="dfn" href="#embedder-policy-value" id="ref-for-embedder-policy-value⑦">value</a>, <var>request</var> and <var>response</var>.</p>
+     <li data-md>
+      <p>If <var>embedder policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint⑧">reporting endpoint</a> is not <code>null</code> and <var>result</var> is <code>blocked</code>, then run these steps:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>blocked url</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url③">URL</a>.</p>
+       <li data-md>
+        <p>Set <var>blocked url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username" id="ref-for-concept-url-username③">username</a> to the empty string, and its <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password" id="ref-for-concept-url-password③">password</a> to <code>null</code>.</p>
+       <li data-md>
+        <p>Set <var>serialized blocked url</var> be the result of executing the <a href="https://url.spec.whatwg.org/#concept-url-serializer">URL serializer</a> on <var>blocked url</var> with
+the <var>exclude fragment flag</var> set.</p>
+       <li data-md>
+        <p>Let <var>body</var> be a new object containing the following properties with keys:</p>
+        <ul>
+         <li data-md>
+          <p>key: "<code>type</code>", value: "<code>CORP</code>".</p>
+         <li data-md>
+          <p>key: "<code>blocked-url</code>", value: <var>serialized blocked url</var>.</p>
+        </ul>
+       <li data-md>
+        <p><a href="https://w3c.github.io/reporting/#queue-report">Queue</a> <var>body</var> as "<code>coep</code>" for <var>embedder policy</var>’s <a data-link-type="dfn" href="#embedder-policy-reporting-endpoint" id="ref-for-embedder-policy-reporting-endpoint⑨">reporting endpoint</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client③">client</a>.</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>result</var>.</p>
+    </ol>
+    <h3 class="heading settled" data-level="3.3" id="integration-sw"><span class="secno">3.3. </span><span class="content">Integration with Service Worker</span><a class="self-link" href="#integration-sw"></a></h3>
+    <p>In https://w3c.github.io/ServiceWorker/#dom-fetchevent-respondwith, replace 10.1 with the following
 items.</p>
-   <ol>
-    <li data-md>
-     <p>If <var>response</var> is not a <code>Response</code> object, or _event_’s request’s associated request’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-mode" id="ref-for-concept-request-mode①">mode</a> is "<code>no-cors</code>" and the result of performing a <a data-link-type="abstract-op" href="#abstract-opdef-cross-origin-resource-policy-check" id="ref-for-abstract-opdef-cross-origin-resource-policy-check④">cross-origin resource policy check</a> with _event_’s request’s associated request and
+    <ol>
+     <li data-md>
+      <p>If <var>response</var> is not a <code>Response</code> object, or _event_’s request’s associated request’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-mode" id="ref-for-concept-request-mode①">mode</a> is "<code>no-cors</code>" and the result of performing a <a data-link-type="abstract-op" href="#abstract-opdef-cross-origin-resource-policy-check" id="ref-for-abstract-opdef-cross-origin-resource-policy-check④">cross-origin resource policy check</a> with _event_’s request’s associated request and
 _response_’s associated response is <code>blocked</code>, then set the respond-with-error flag.</p>
-   </ol>
-   <p>Also add the following note.</p>
-   <p>The <a data-link-type="abstract-op" href="#abstract-opdef-cross-origin-resource-policy-check" id="ref-for-abstract-opdef-cross-origin-resource-policy-check⑤">cross-origin resource policy check</a> performed here ensures that a Service Worker
+    </ol>
+    <p>Also add the following note.</p>
+    <p>The <a data-link-type="abstract-op" href="#abstract-opdef-cross-origin-resource-policy-check" id="ref-for-abstract-opdef-cross-origin-resource-policy-check⑤">cross-origin resource policy check</a> performed here ensures that a Service Worker
 cannot respond to a client that requires CORP with an opaque response that doesn’t assert CORP.</p>
-   <h2 class="heading settled" data-level="4" id="impl-considerations"><span class="secno">4. </span><span class="content">Implementation Considerations</span><a class="self-link" href="#impl-considerations"></a></h2>
-   <h3 class="heading settled" data-level="4.1" id="why-not-cors"><span class="secno">4.1. </span><span class="content">Why not require CORS instead?</span><a class="self-link" href="#why-not-cors"></a></h3>
-   <p>An earlier version of this propsal leaned on CORS rather than CORP. Why didn’t we run with that
+    <h2 class="heading settled" data-level="4" id="impl-considerations"><span class="secno">4. </span><span class="content">Implementation Considerations</span><a class="self-link" href="#impl-considerations"></a></h2>
+    <h3 class="heading settled" data-level="4.1" id="why-not-cors"><span class="secno">4.1. </span><span class="content">Why not require CORS instead?</span><a class="self-link" href="#why-not-cors"></a></h3>
+    <p>An earlier version of this propsal leaned on CORS rather than CORP. Why didn’t we run with that
 model instead?</p>
-   <p>This proposal posits that there’s a meaningful distinction between a server’s assertions that "You,
+    <p>This proposal posits that there’s a meaningful distinction between a server’s assertions that "You,
 vague acquaintance, may embed me." and "You, dearest friend, may read me." <code>Cross-Origin-Resource-Policy</code> grants no explicit access to a resources' content, unlike CORS, and
 seems like it’s just good-enough to support the explicit declaration of embeddableness that this
 proposal requires. CORS goes further, and especially in the short-term it seems that there’s real
 risk in developers blindly enabling CORS in order to meet the embedding requirements we want to
 impose here, opening themselves up to direct attack in the process.</p>
-   <p>That is, it seems likely that some subset of developers would implement a CORS requirement in the
+    <p>That is, it seems likely that some subset of developers would implement a CORS requirement in the
 simplest way possible, by reflecting the <code>Origin</code> header in an <code>Access-Control-Allow-Origin</code> header.
 If these resources contain interesting data about users (as advertisements, for example, are wont to
 do), then it’s possible that data will end up being more widely available than expected.</p>
-   <p>CORP does not create the same risk. It seems strictly lower-privilege than CORS, and a reasonable
+    <p>CORP does not create the same risk. It seems strictly lower-privilege than CORS, and a reasonable
 place for us to start.</p>
-   <h3 class="heading settled" data-level="4.2" id="forward-compat"><span class="secno">4.2. </span><span class="content">Forward-compatibility</span><a class="self-link" href="#forward-compat"></a></h3>
-   <p>The header defined in this document is small and single-purpose, which is a real advantage for
+    <h3 class="heading settled" data-level="4.2" id="forward-compat"><span class="secno">4.2. </span><span class="content">Forward-compatibility</span><a class="self-link" href="#forward-compat"></a></h3>
+    <p>The header defined in this document is small and single-purpose, which is a real advantage for
 comprehensibility. I wonder, however, if an extensible alternative would be reasonable. For
 example, if we’re serious about moving to credentialless requests, it would be annoying to do so by
 defining yet another header. Perhaps something more generic that accepts a <a data-link-type="dfn" href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.1" id="ref-for-section-3.1">dictionary</a> rather than a single token? That is:</p>
 <pre>Embedee-Policy: opt-in=required, credentials=cors-only
 </pre>
-   <p>Perhaps it will be possible to do everything we want by defining a new tokens, but I worry a bit
+    <p>Perhaps it will be possible to do everything we want by defining a new tokens, but I worry a bit
 that we’ll follow <a data-link-type="biblio" href="#biblio-referrer-policy">[Referrer-Policy]</a> into some pretty convoluted token names if we go that route.
 Splitting out the axes along which we’d like to make decisions seems like it might be a good
 strategy to consider.</p>
-   <h3 class="heading settled" data-level="4.3" id="cascade-vs-require"><span class="secno">4.3. </span><span class="content">Cascading vs. requiring embedder policies</span><a class="self-link" href="#cascade-vs-require"></a></h3>
-   <p>An earlier version of this proposal called for a nested document’s <a data-link-type="dfn" href="#document-embedder-policy" id="ref-for-document-embedder-policy⑧">embedder policy</a> to
+    <h3 class="heading settled" data-level="4.3" id="cascade-vs-require"><span class="secno">4.3. </span><span class="content">Cascading vs. requiring embedder policies</span><a class="self-link" href="#cascade-vs-require"></a></h3>
+    <p>An earlier version of this proposal called for a nested document’s <a data-link-type="dfn" href="#document-embedder-policy" id="ref-for-document-embedder-policy⑧">embedder policy</a> to
 be inherited from its parent. This would ensure that a document that asserted <code>require-corp</code> would
 require its framed children to do the same.</p>
-   <p>We decided that this is the wrong model to start with. Instead, we now require the framed document
+    <p>We decided that this is the wrong model to start with. Instead, we now require the framed document
 itself to assert <code>Cross-Origin-Embedder-Policy: require-corp</code>, and block the load if it doesn’t.
 That seems safer, insofar as it would give the embedder less control over the embedee’s state. It
 also ensures that the embedee’s developer would always see consistent behavior in the given document
 no matter whether its loaded as a frame or as a top-level document.</p>
-   <p>This might be a requirement we can relax in the future, as it does have potential implications for
+    <p>This might be a requirement we can relax in the future, as it does have potential implications for
 eventual deployment. It makes sense to begin with the requirement, however, as loosening constraints
 is significantly simpler than imposing new constraints in the future.</p>
+   </div>
   </main>
   <div data-fill-with="conformance">
    <h2 class="no-ref no-num heading settled" id="conformance"><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>
@@ -2147,6 +2191,7 @@ is significantly simpler than imposing new constraints in the future.</p>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
+   <li><a href="#abstract-opdef-check-a-global-objects-embedder-policy">check a global object’s embedder policy</a><span>, in §3.1.2</span>
    <li><a href="#http-headerdef-cross-origin-embedder-policy">Cross-Origin-Embedder-Policy</a><span>, in §2.1</span>
    <li><a href="#http-headerdef-cross-origin-embedder-policy-report-only">Cross-Origin-Embedder-Policy-Report-Only</a><span>, in §2.2</span>
    <li><a href="#abstract-opdef-cross-origin-resource-policy-check">cross-origin resource policy check</a><span>, in §3.2.1</span>
@@ -2162,8 +2207,9 @@ is significantly simpler than imposing new constraints in the future.</p>
    <li><a href="#abstract-opdef-initialize-a-global-objects-embedder-policy-from-a-response">initialize a global object’s embedder policy from a response</a><span>, in §3.1.1</span>
    <li><a href="#abstract-opdef-obtain-a-responses-embedder-policy">obtain a response’s embedder policy</a><span>, in §2.3</span>
    <li><a href="#abstract-opdef-obtain-a-responses-embedder-policy">parse header</a><span>, in §2.3</span>
-   <li><a href="#abstract-opdef-process-navigation-response">process navigation response</a><span>, in §3.1.2</span>
-   <li><a href="#abstract-opdef-queue-coep-navigation-violation">queue coep navigation violation</a><span>, in §3.1.2</span>
+   <li><a href="#abstract-opdef-process-navigation-response">process navigation response</a><span>, in §3.1.3</span>
+   <li><a href="#abstract-opdef-queue-coep-navigation-violation">queue coep navigation violation</a><span>, in §3.1.3</span>
+   <li><a href="#abstract-opdef-queue-coep-worker-violation">queue coep worker violation</a><span>, in §3.1.2</span>
    <li><a href="#embedder-policy-reporting-endpoint">reporting endpoint</a><span>, in §3.1</span>
    <li><a href="#embedder-policy-report-only-reporting-endpoint">report only reporting endpoint</a><span>, in §3.1</span>
    <li><a href="#embedder-policy-report-only-value">report only value</a><span>, in §3.1</span>
@@ -2203,8 +2249,9 @@ is significantly simpler than imposing new constraints in the future.</p>
   <aside class="dfn-panel" data-for="term-for-concept-request-current-url">
    <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">https://fetch.spec.whatwg.org/#concept-request-current-url</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request-current-url">3.1.2. Process a navigation response</a>
-    <li><a href="#ref-for-concept-request-current-url①">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-request-current-url②">(2)</a>
+    <li><a href="#ref-for-concept-request-current-url">3.1.2. Checking a global object’s Embedder policy</a>
+    <li><a href="#ref-for-concept-request-current-url①">3.1.3. Process a navigation response</a>
+    <li><a href="#ref-for-concept-request-current-url②">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-request-current-url③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-destination">
@@ -2254,7 +2301,7 @@ is significantly simpler than imposing new constraints in the future.</p>
   <aside class="dfn-panel" data-for="term-for-concept-network-error">
    <a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-network-error">3.1. Integration with HTML</a>
+    <li><a href="#ref-for-concept-network-error">3.1. Integration with HTML</a> <a href="#ref-for-concept-network-error①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-origin">
@@ -2266,9 +2313,10 @@ is significantly simpler than imposing new constraints in the future.</p>
   <aside class="dfn-panel" data-for="term-for-concept-request">
    <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request">3.1.2. Process a navigation response</a> <a href="#ref-for-concept-request①">(2)</a>
-    <li><a href="#ref-for-concept-request②">3.2. Integration with Fetch</a>
-    <li><a href="#ref-for-concept-request③">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-request④">(2)</a>
+    <li><a href="#ref-for-concept-request">3.1.2. Checking a global object’s Embedder policy</a> <a href="#ref-for-concept-request①">(2)</a>
+    <li><a href="#ref-for-concept-request②">3.1.3. Process a navigation response</a> <a href="#ref-for-concept-request③">(2)</a>
+    <li><a href="#ref-for-concept-request④">3.2. Integration with Fetch</a>
+    <li><a href="#ref-for-concept-request⑤">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-request⑥">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-reserved-client">
@@ -2283,7 +2331,7 @@ is significantly simpler than imposing new constraints in the future.</p>
    <ul>
     <li><a href="#ref-for-concept-response">2.3. Parsing</a>
     <li><a href="#ref-for-concept-response①">3.1.1. Initializing a global object’s Embedder policy</a>
-    <li><a href="#ref-for-concept-response②">3.1.2. Process a navigation response</a>
+    <li><a href="#ref-for-concept-response②">3.1.3. Process a navigation response</a>
     <li><a href="#ref-for-concept-response③">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-response④">(2)</a>
    </ul>
   </aside>
@@ -2293,16 +2341,10 @@ is significantly simpler than imposing new constraints in the future.</p>
     <li><a href="#ref-for-concept-response-url">3.1.1. Initializing a global object’s Embedder policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dedicatedworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dedicatedworkerglobalscope">3.1.1. Initializing a global object’s Embedder policy</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-sharedworkerglobalscope">
    <a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-sharedworkerglobalscope">3.1.1. Initializing a global object’s Embedder policy</a>
+    <li><a href="#ref-for-sharedworkerglobalscope">3.1.2. Checking a global object’s Embedder policy</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-window">
@@ -2333,33 +2375,35 @@ is significantly simpler than imposing new constraints in the future.</p>
    <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">3.1. Integration with HTML</a>
-    <li><a href="#ref-for-browsing-context①">3.1.2. Process a navigation response</a>
+    <li><a href="#ref-for-browsing-context①">3.1.3. Process a navigation response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-child-browsing-context">
    <a href="https://html.spec.whatwg.org/multipage/browsers.html#child-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#child-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-child-browsing-context">3.1. Integration with HTML</a>
-    <li><a href="#ref-for-child-browsing-context①">3.1.2. Process a navigation response</a>
+    <li><a href="#ref-for-child-browsing-context①">3.1.3. Process a navigation response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-bc-container-document">
    <a href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document">https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-bc-container-document">3.1.2. Process a navigation response</a> <a href="#ref-for-bc-container-document①">(2)</a> <a href="#ref-for-bc-container-document②">(3)</a>
+    <li><a href="#ref-for-bc-container-document">3.1.3. Process a navigation response</a> <a href="#ref-for-bc-container-document①">(2)</a> <a href="#ref-for-bc-container-document②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-environment-settings-object">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">3.1. Integration with HTML</a>
-    <li><a href="#ref-for-environment-settings-object①">3.1.2. Process a navigation response</a>
+    <li><a href="#ref-for-environment-settings-object①">3.1.2. Checking a global object’s Embedder policy</a> <a href="#ref-for-environment-settings-object②">(2)</a>
+    <li><a href="#ref-for-environment-settings-object③">3.1.3. Process a navigation response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-global-object">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">https://html.spec.whatwg.org/multipage/webappapis.html#global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-global-object">3.1.1. Initializing a global object’s Embedder policy</a>
+    <li><a href="#ref-for-global-object①">3.1.2. Checking a global object’s Embedder policy</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-origin-host">
@@ -2377,7 +2421,7 @@ is significantly simpler than imposing new constraints in the future.</p>
   <aside class="dfn-panel" data-for="term-for-nested-browsing-context">
    <a href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-nested-browsing-context">3.1.2. Process a navigation response</a>
+    <li><a href="#ref-for-nested-browsing-context">3.1.3. Process a navigation response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-open">
@@ -2454,7 +2498,7 @@ is significantly simpler than imposing new constraints in the future.</p>
   <aside class="dfn-panel" data-for="term-for-serviceworkerglobalscope">
    <a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-serviceworkerglobalscope">3.1.1. Initializing a global object’s Embedder policy</a>
+    <li><a href="#ref-for-serviceworkerglobalscope">3.1.2. Checking a global object’s Embedder policy</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-origin">
@@ -2466,8 +2510,9 @@ is significantly simpler than imposing new constraints in the future.</p>
   <aside class="dfn-panel" data-for="term-for-concept-url-password">
    <a href="https://url.spec.whatwg.org/#concept-url-password">https://url.spec.whatwg.org/#concept-url-password</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-password">3.1.2. Process a navigation response</a>
-    <li><a href="#ref-for-concept-url-password①">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-url-password②">(2)</a>
+    <li><a href="#ref-for-concept-url-password">3.1.2. Checking a global object’s Embedder policy</a>
+    <li><a href="#ref-for-concept-url-password①">3.1.3. Process a navigation response</a>
+    <li><a href="#ref-for-concept-url-password②">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-url-password③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
@@ -2479,8 +2524,9 @@ is significantly simpler than imposing new constraints in the future.</p>
   <aside class="dfn-panel" data-for="term-for-concept-url-username">
    <a href="https://url.spec.whatwg.org/#concept-url-username">https://url.spec.whatwg.org/#concept-url-username</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-username">3.1.2. Process a navigation response</a>
-    <li><a href="#ref-for-concept-url-username①">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-url-username②">(2)</a>
+    <li><a href="#ref-for-concept-url-username">3.1.2. Checking a global object’s Embedder policy</a>
+    <li><a href="#ref-for-concept-url-username①">3.1.3. Process a navigation response</a>
+    <li><a href="#ref-for-concept-url-username②">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-concept-url-username③">(2)</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -2519,7 +2565,6 @@ is significantly simpler than imposing new constraints in the future.</p>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-dedicatedworkerglobalscope" style="color:initial">DedicatedWorkerGlobalScope</span>
      <li><span class="dfn-paneled" id="term-for-sharedworkerglobalscope" style="color:initial">SharedWorkerGlobalScope</span>
      <li><span class="dfn-paneled" id="term-for-window" style="color:initial">Window</span>
      <li><span class="dfn-paneled" id="term-for-workerglobalscope" style="color:initial">WorkerGlobalScope</span>
@@ -2616,7 +2661,7 @@ error-handling behavior.<a href="#issue-4328816a"> ↵ </a></div>
    <ul>
     <li><a href="#ref-for-abstract-opdef-obtain-a-responses-embedder-policy">3.1. Integration with HTML</a>
     <li><a href="#ref-for-abstract-opdef-obtain-a-responses-embedder-policy①">3.1.1. Initializing a global object’s Embedder policy</a>
-    <li><a href="#ref-for-abstract-opdef-obtain-a-responses-embedder-policy②">3.1.2. Process a navigation response</a>
+    <li><a href="#ref-for-abstract-opdef-obtain-a-responses-embedder-policy②">3.1.3. Process a navigation response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="embedder-policy">
@@ -2625,7 +2670,7 @@ error-handling behavior.<a href="#issue-4328816a"> ↵ </a></div>
     <li><a href="#ref-for-embedder-policy">2.3. Parsing</a>
     <li><a href="#ref-for-embedder-policy①">3.1. Integration with HTML</a> <a href="#ref-for-embedder-policy②">(2)</a> <a href="#ref-for-embedder-policy③">(3)</a>
     <li><a href="#ref-for-embedder-policy④">3.1.1. Initializing a global object’s Embedder policy</a> <a href="#ref-for-embedder-policy⑤">(2)</a> <a href="#ref-for-embedder-policy⑥">(3)</a>
-    <li><a href="#ref-for-embedder-policy⑦">3.1.2. Process a navigation response</a>
+    <li><a href="#ref-for-embedder-policy⑦">3.1.3. Process a navigation response</a>
     <li><a href="#ref-for-embedder-policy⑧">3.2. Integration with Fetch</a> <a href="#ref-for-embedder-policy⑨">(2)</a>
     <li><a href="#ref-for-embedder-policy①⓪">3.2.1. Cross-Origin Resource Policy Checks</a>
    </ul>
@@ -2634,8 +2679,9 @@ error-handling behavior.<a href="#issue-4328816a"> ↵ </a></div>
    <b><a href="#embedder-policy-value">#embedder-policy-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-embedder-policy-value">2.3. Parsing</a>
-    <li><a href="#ref-for-embedder-policy-value①">3.1.2. Process a navigation response</a> <a href="#ref-for-embedder-policy-value②">(2)</a> <a href="#ref-for-embedder-policy-value③">(3)</a>
-    <li><a href="#ref-for-embedder-policy-value④">3.2.1. Cross-Origin Resource Policy Checks</a>
+    <li><a href="#ref-for-embedder-policy-value①">3.1.2. Checking a global object’s Embedder policy</a> <a href="#ref-for-embedder-policy-value②">(2)</a> <a href="#ref-for-embedder-policy-value③">(3)</a>
+    <li><a href="#ref-for-embedder-policy-value④">3.1.3. Process a navigation response</a> <a href="#ref-for-embedder-policy-value⑤">(2)</a> <a href="#ref-for-embedder-policy-value⑥">(3)</a>
+    <li><a href="#ref-for-embedder-policy-value⑦">3.2.1. Cross-Origin Resource Policy Checks</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="embedder-policy-reporting-endpoint">
@@ -2643,16 +2689,18 @@ error-handling behavior.<a href="#issue-4328816a"> ↵ </a></div>
    <ul>
     <li><a href="#ref-for-embedder-policy-reporting-endpoint">2.3. Parsing</a>
     <li><a href="#ref-for-embedder-policy-reporting-endpoint①">3.1.1. Initializing a global object’s Embedder policy</a> <a href="#ref-for-embedder-policy-reporting-endpoint②">(2)</a> <a href="#ref-for-embedder-policy-reporting-endpoint③">(3)</a>
-    <li><a href="#ref-for-embedder-policy-reporting-endpoint④">3.1.2. Process a navigation response</a> <a href="#ref-for-embedder-policy-reporting-endpoint⑤">(2)</a>
-    <li><a href="#ref-for-embedder-policy-reporting-endpoint⑥">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-embedder-policy-reporting-endpoint⑦">(2)</a>
+    <li><a href="#ref-for-embedder-policy-reporting-endpoint④">3.1.2. Checking a global object’s Embedder policy</a> <a href="#ref-for-embedder-policy-reporting-endpoint⑤">(2)</a>
+    <li><a href="#ref-for-embedder-policy-reporting-endpoint⑥">3.1.3. Process a navigation response</a> <a href="#ref-for-embedder-policy-reporting-endpoint⑦">(2)</a>
+    <li><a href="#ref-for-embedder-policy-reporting-endpoint⑧">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-embedder-policy-reporting-endpoint⑨">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="embedder-policy-report-only-value">
    <b><a href="#embedder-policy-report-only-value">#embedder-policy-report-only-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-embedder-policy-report-only-value">2.3. Parsing</a>
-    <li><a href="#ref-for-embedder-policy-report-only-value①">3.1.2. Process a navigation response</a>
-    <li><a href="#ref-for-embedder-policy-report-only-value②">3.2.1. Cross-Origin Resource Policy Checks</a>
+    <li><a href="#ref-for-embedder-policy-report-only-value①">3.1.2. Checking a global object’s Embedder policy</a>
+    <li><a href="#ref-for-embedder-policy-report-only-value②">3.1.3. Process a navigation response</a>
+    <li><a href="#ref-for-embedder-policy-report-only-value③">3.2.1. Cross-Origin Resource Policy Checks</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="embedder-policy-report-only-reporting-endpoint">
@@ -2660,15 +2708,16 @@ error-handling behavior.<a href="#issue-4328816a"> ↵ </a></div>
    <ul>
     <li><a href="#ref-for-embedder-policy-report-only-reporting-endpoint">2.3. Parsing</a>
     <li><a href="#ref-for-embedder-policy-report-only-reporting-endpoint①">3.1.1. Initializing a global object’s Embedder policy</a> <a href="#ref-for-embedder-policy-report-only-reporting-endpoint②">(2)</a> <a href="#ref-for-embedder-policy-report-only-reporting-endpoint③">(3)</a>
-    <li><a href="#ref-for-embedder-policy-report-only-reporting-endpoint④">3.1.2. Process a navigation response</a> <a href="#ref-for-embedder-policy-report-only-reporting-endpoint⑤">(2)</a>
-    <li><a href="#ref-for-embedder-policy-report-only-reporting-endpoint⑥">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-embedder-policy-report-only-reporting-endpoint⑦">(2)</a>
+    <li><a href="#ref-for-embedder-policy-report-only-reporting-endpoint④">3.1.2. Checking a global object’s Embedder policy</a> <a href="#ref-for-embedder-policy-report-only-reporting-endpoint⑤">(2)</a>
+    <li><a href="#ref-for-embedder-policy-report-only-reporting-endpoint⑥">3.1.3. Process a navigation response</a> <a href="#ref-for-embedder-policy-report-only-reporting-endpoint⑦">(2)</a>
+    <li><a href="#ref-for-embedder-policy-report-only-reporting-endpoint⑧">3.2.1. Cross-Origin Resource Policy Checks</a> <a href="#ref-for-embedder-policy-report-only-reporting-endpoint⑨">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="document-embedder-policy">
    <b><a href="#document-embedder-policy">#document-embedder-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-embedder-policy">3.1. Integration with HTML</a> <a href="#ref-for-document-embedder-policy①">(2)</a> <a href="#ref-for-document-embedder-policy②">(3)</a> <a href="#ref-for-document-embedder-policy③">(4)</a> <a href="#ref-for-document-embedder-policy④">(5)</a> <a href="#ref-for-document-embedder-policy⑤">(6)</a>
-    <li><a href="#ref-for-document-embedder-policy⑥">3.1.2. Process a navigation response</a> <a href="#ref-for-document-embedder-policy⑦">(2)</a>
+    <li><a href="#ref-for-document-embedder-policy⑥">3.1.3. Process a navigation response</a> <a href="#ref-for-document-embedder-policy⑦">(2)</a>
     <li><a href="#ref-for-document-embedder-policy⑧">4.3. Cascading vs. requiring embedder policies</a>
    </ul>
   </aside>
@@ -2682,7 +2731,8 @@ error-handling behavior.<a href="#issue-4328816a"> ↵ </a></div>
   <aside class="dfn-panel" data-for="environment-settings-object-embedder-policy">
    <b><a href="#environment-settings-object-embedder-policy">#environment-settings-object-embedder-policy</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-environment-settings-object-embedder-policy">3.2.1. Cross-Origin Resource Policy Checks</a>
+    <li><a href="#ref-for-environment-settings-object-embedder-policy">3.1.2. Checking a global object’s Embedder policy</a>
+    <li><a href="#ref-for-environment-settings-object-embedder-policy①">3.2.1. Cross-Origin Resource Policy Checks</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-initialize-a-global-objects-embedder-policy-from-a-response">
@@ -2691,10 +2741,16 @@ error-handling behavior.<a href="#issue-4328816a"> ↵ </a></div>
     <li><a href="#ref-for-abstract-opdef-initialize-a-global-objects-embedder-policy-from-a-response">3.1. Integration with HTML</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="abstract-opdef-queue-coep-worker-violation">
+   <b><a href="#abstract-opdef-queue-coep-worker-violation">#abstract-opdef-queue-coep-worker-violation</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-abstract-opdef-queue-coep-worker-violation">3.1.2. Checking a global object’s Embedder policy</a> <a href="#ref-for-abstract-opdef-queue-coep-worker-violation①">(2)</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-queue-coep-navigation-violation">
    <b><a href="#abstract-opdef-queue-coep-navigation-violation">#abstract-opdef-queue-coep-navigation-violation</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-queue-coep-navigation-violation">3.1.2. Process a navigation response</a> <a href="#ref-for-abstract-opdef-queue-coep-navigation-violation①">(2)</a>
+    <li><a href="#ref-for-abstract-opdef-queue-coep-navigation-violation">3.1.3. Process a navigation response</a> <a href="#ref-for-abstract-opdef-queue-coep-navigation-violation①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-process-navigation-response">


### PR DESCRIPTION
Stop inheriting owner's policy, and use response's policy instead. Also
add a check to keep the invariance that when owner's COEP is
"require-corp" then the dedicated worker's COEP must also be
"require-corp".

Fixes whatwg/html#4924.